### PR TITLE
Fix joystick pointer handling at viewport edges

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -940,22 +940,33 @@ function startJoystickDrag(e) {
     joystickState.maxDistance = rect.width / 2 * 0.8;
 }
 
+function getPointerPosition(e) {
+    if (typeof e.clientX === 'number' && typeof e.clientY === 'number') {
+        return { x: e.clientX, y: e.clientY };
+    }
+
+    if (e.touches && e.touches.length > 0) {
+        return { x: e.touches[0].clientX, y: e.touches[0].clientY };
+    }
+
+    return null;
+}
+
 function handleJoystickDrag(e) {
     if (!joystickState.isDragging) return;
     
     e.preventDefault();
     
-    const clientX = e.clientX || (e.touches && e.touches[0].clientX);
-    const clientY = e.clientY || (e.touches && e.touches[0].clientY);
+    const pointerPosition = getPointerPosition(e);
     
-    if (!clientX || !clientY) return;
+    if (!pointerPosition) return;
     
     const rect = joystickState.baseRect;
     const centerX = rect.left + rect.width / 2;
     const centerY = rect.top + rect.height / 2;
     
-    let deltaX = clientX - centerX;
-    let deltaY = clientY - centerY;
+    let deltaX = pointerPosition.x - centerX;
+    let deltaY = pointerPosition.y - centerY;
     
     const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
     
@@ -998,11 +1009,11 @@ function moveJoystickToPosition(e) {
     const centerX = rect.left + rect.width / 2;
     const centerY = rect.top + rect.height / 2;
     
-    const clientX = e.clientX || (e.touches && e.touches[0].clientX);
-    const clientY = e.clientY || (e.touches && e.touches[0].clientY);
+    const pointerPosition = getPointerPosition(e);
+    if (!pointerPosition) return;
     
-    let deltaX = clientX - centerX;
-    let deltaY = clientY - centerY;
+    let deltaX = pointerPosition.x - centerX;
+    let deltaY = pointerPosition.y - centerY;
     
     const maxDistance = rect.width / 2 * 0.8;
     const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
@@ -1017,7 +1028,7 @@ function moveJoystickToPosition(e) {
     joystickState.baseRect = rect;
     joystickState.maxDistance = maxDistance;
     
-    handleJoystickDrag({ clientX, clientY, preventDefault: () => {} });
+    handleJoystickDrag({ clientX: pointerPosition.x, clientY: pointerPosition.y, preventDefault: () => {} });
 }
 
 function handleCenterButtonPress() {


### PR DESCRIPTION
### Motivation
- The mobile joystick could drop input when the pointer was at the left/top edges because truthy checks treated `clientX`/`clientY` equal to `0` as missing values. 
- This made control unreliable near viewport edges and for some touch interactions.

### Description
- Added a `getPointerPosition(e)` helper that reliably extracts mouse or touch coordinates and returns `null` only when no pointer is present. 
- Replaced previous truthy checks with the helper in `handleJoystickDrag` to avoid skipping valid `0` coordinates. 
- Updated `moveJoystickToPosition` to use the same helper and to forward coordinates into the drag handler consistently. 
- Changes applied to `public/app.js` to centralize pointer extraction and make joystick interactions robust at viewport edges.

### Testing
- Ran `node --check public/app.js` which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699abea9fc5c8321a23f733184e8675a)