### PR TITLE
feat(game): game-feel glow-up — crisp turning, HiDPI, juice + combos

### DIFF
--- a/public/css/desktop.css
+++ b/public/css/desktop.css
@@ -205,10 +205,16 @@
 }
 
 #game-canvas {
+    /* Display size stays logical (600x600); the JS sets a higher-resolution backing
+       store for HiDPI. aspect-ratio keeps it square when responsively shrunk. */
+    display: block;
+    width: 600px;
+    height: 600px;
+    aspect-ratio: 1 / 1;
     border: 3px solid;
     border-image: linear-gradient(45deg, var(--color-primary), var(--color-warning), var(--color-teal-600), var(--color-teal-700)) 1;
     background: var(--color-background);
-    box-shadow: 
+    box-shadow:
         0 0 50px rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.4),
         inset 0 0 50px rgba(var(--color-teal-700-rgb, var(--color-teal-700)), 0.1);
 }
@@ -413,6 +419,7 @@
         width: 100%;
         max-width: 600px;
         flex-direction: row;
+        flex-wrap: wrap;
         justify-content: center;
     }
     
@@ -476,4 +483,50 @@
     font-weight: var(--font-weight-bold);
     margin: var(--space-16) 0 0;
     text-shadow: 0 0 8px rgba(255, 209, 102, 0.6);
+}
+
+/* Desktop controls legend — tells the host they can play keyboard-only. */
+.controls-hint {
+    margin: 0;
+    width: 100%;
+    text-align: center;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    line-height: var(--line-height-normal);
+}
+
+.controls-hint kbd {
+    display: inline-block;
+    font-family: var(--font-family-mono);
+    font-size: var(--font-size-xs);
+    color: var(--color-primary);
+    background: rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.12);
+    border: 1px solid rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.4);
+    border-radius: var(--radius-sm);
+    padding: 1px 6px;
+    margin: 0 2px;
+}
+
+/* Combo streak badge — floats over the top-right of the board during a streak. */
+.combo-display {
+    position: absolute;
+    top: var(--space-12);
+    right: var(--space-12);
+    font-family: 'Orbitron', var(--font-family-base);
+    font-weight: var(--font-weight-bold);
+    font-size: var(--font-size-2xl);
+    color: #ffcf4d;
+    background: rgba(10, 10, 16, 0.55);
+    padding: var(--space-6) var(--space-12);
+    border-radius: var(--radius-full);
+    border: 1px solid rgba(255, 207, 77, 0.5);
+    text-shadow: 0 0 10px rgba(255, 207, 77, 0.8);
+    pointer-events: none;
+    z-index: 5;
+    animation: comboPop var(--duration-fast) var(--ease-standard);
+}
+
+@keyframes comboPop {
+    0% { transform: scale(0.6); opacity: 0; }
+    100% { transform: scale(1); opacity: 1; }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -112,6 +112,7 @@
             <div class="game-area">
                 <div class="game-board-container">
                     <canvas id="game-canvas" width="600" height="600"></canvas>
+                    <div id="combo-display" class="combo-display hidden"></div>
                     <div id="game-over" class="game-over hidden">
                         <div class="game-over-content">
                             <h2>Game Over!</h2>
@@ -136,6 +137,10 @@
                             <span id="high-score" class="score-value">0</span>
                         </div>
                     </div>
+
+                    <p class="controls-hint">
+                        <kbd>Space</kbd> start · <kbd>↑ ↓ ← →</kbd> / <kbd>WASD</kbd> steer · or 📱 scan to play from your phone
+                    </p>
 
                     <div class="connection-card">
                         <div class="session-code">
@@ -206,6 +211,7 @@
     <script src="js/state.js"></script>
     <script src="js/leaderboard.js"></script>
     <script src="js/sound.js"></script>
+    <script src="js/effects.js"></script>
     <script src="js/network.js"></script>
     <script src="js/game.js"></script>
     <script src="js/controller.js"></script>

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -62,15 +62,20 @@ const gameConfig = {
     foodSize: 8,
     baseSpeed: 2.0,       // Minimum constant speed
     maxSpeedBoost: 1.5,   // Speed added when joystick is fully angled
-    speedIncrease: 0.1,   // Speed increment per food item
-    maxSpeed: 5,          // Maximum allowed speed limit
-    turnSpeed: 0.08,      // How fast the snake turns (radians)
+    speedIncrease: 0.06,  // Speed increment per food item (gentle ramp = a flow curve, not a sprint)
+    maxSpeed: 4,          // Maximum allowed speed limit (kept controllable alongside turn coupling)
+    turnSpeed: 0.13,      // Base turn step per 60fps frame (radians); crisper than the old 0.08
+    maxTurnSpeedFactor: 2.2, // Cap on how much faster turning scales with speed (keeps turn radius ~constant)
     segmentSpacing: 15,   // Gap between snake segments
     wallMargin: 20,       // Distance from edge considering as wall
     minSelfCollisionSegments: 8, // Minimum segments before self-collision is possible
-    
+
+    // Combo / streak scoring
+    comboWindowMs: 4500, // Eat again within this window to extend the streak
+    maxCombo: 6,         // Cap on the score multiplier
+
     // Optimization settings
-    joystickThrottleMs: 50, // Limits joystick update frequency
+    joystickThrottleMs: 33, // Limits joystick update frequency (~30Hz for snappier phone input)
     movementUpdateMs: 25,   // Frames per second interval
     
     // Connection settings
@@ -78,15 +83,17 @@ const gameConfig = {
     retryDelayMs: 2000,
 };
 
-// Palette used for painting canvas elements
+// Palette used for painting canvas elements. Aligned with the teal brand tokens in
+// css/variables.css so the board and the UI chrome read as one cohesive design, with
+// a warm gold food as the high-contrast pop (also matches the "new high score" gold).
 const colors = {
     background: "#0a0a0a",
-    snake: "#ff1493",
-    snakeHead: "#ff6b35",
-    food: "#7209b7",
+    snake: "#19c3b2",      // teal body — matches the brand teal UI
+    snakeHead: "#7df9ff",  // bright cyan head leads the body
+    food: "#ffcf4d",       // warm gold pop, high contrast against the teal snake
     border: "#333333",
     text: "#ffffff",
-    accent: "#ff1493"
+    accent: "#22d3c5"      // teal accent
 };
 
 // Enum representing possible game states

--- a/public/js/effects.js
+++ b/public/js/effects.js
@@ -1,0 +1,156 @@
+// ==========================================
+// VISUAL EFFECTS — particles, ripples, score pops, screen shake
+// ==========================================
+// A lightweight "juice" layer drawn on top of the game each frame. All motion is
+// integrated analytically from a timestamp (Date.now()) so it is frame-rate
+// independent — it looks the same at 60 / 120 / 144Hz, matching the game loop. No
+// asset files; everything is canvas primitives. Loaded before game.js, which calls
+// these helpers from moveSnake()/gameOver()/renderGame().
+
+const effects = {
+    particles: [],
+    ripples: [],
+    scorePops: [],
+    shake: { until: 0, magnitude: 0, duration: 1 }
+};
+
+/**
+ * Burst of particles flying outward from (x, y) plus an expanding ring — e.g. when
+ * food is eaten or the snake crashes.
+ * @param {number} x
+ * @param {number} y
+ * @param {string} color
+ */
+function spawnFoodBurst(x, y, color) {
+    const now = Date.now();
+    const count = 10;
+    for (let i = 0; i < count; i++) {
+        const angle = (Math.PI * 2 * i) / count + Math.random() * 0.5;
+        const speed = 0.06 + Math.random() * 0.10; // px per ms
+        effects.particles.push({
+            x, y,
+            vx: Math.cos(angle) * speed,
+            vy: Math.sin(angle) * speed,
+            born: now,
+            ttl: 360 + Math.random() * 160,
+            size: 2 + Math.random() * 2.5,
+            color: color || '#ffcf4d'
+        });
+    }
+    effects.ripples.push({ x, y, born: now, ttl: 380, maxR: 34, color: color || '#ffcf4d' });
+}
+
+/**
+ * Floating text that rises and fades — e.g. "+20 x2" score gain.
+ * @param {number} x
+ * @param {number} y
+ * @param {string} text
+ * @param {string} color
+ */
+function spawnScorePop(x, y, text, color) {
+    effects.scorePops.push({ x, y, text, born: Date.now(), ttl: 700, color: color || '#ffffff' });
+}
+
+/**
+ * Kick off a screen shake.
+ * @param {number} magnitude - peak offset in px.
+ * @param {number} durationMs
+ */
+function triggerShake(magnitude, durationMs) {
+    effects.shake = { until: Date.now() + durationMs, magnitude, duration: durationMs };
+}
+
+/**
+ * Current shake translation for this frame (decays linearly to zero), or {x:0,y:0}.
+ * @returns {{x:number, y:number}}
+ */
+function getShakeOffset() {
+    const remaining = effects.shake.until - Date.now();
+    if (remaining <= 0) return { x: 0, y: 0 };
+    const intensity = (remaining / effects.shake.duration) * effects.shake.magnitude;
+    return {
+        x: (Math.random() * 2 - 1) * intensity,
+        y: (Math.random() * 2 - 1) * intensity
+    };
+}
+
+/**
+ * Advance and draw all active effects. Call once per frame inside renderGame, in the
+ * same logical coordinate space as the game. Expired effects are pruned in place.
+ * @param {CanvasRenderingContext2D} ctx
+ */
+function updateAndDrawEffects(ctx) {
+    const now = Date.now();
+
+    // Ripples (expanding rings).
+    for (let i = effects.ripples.length - 1; i >= 0; i--) {
+        const r = effects.ripples[i];
+        const t = (now - r.born) / r.ttl;
+        if (t >= 1) { effects.ripples.splice(i, 1); continue; }
+        ctx.save();
+        ctx.globalAlpha = 1 - t;
+        ctx.strokeStyle = r.color;
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.arc(r.x, r.y, r.maxR * t, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.restore();
+    }
+
+    // Particles (fly out, slight gravity, fade).
+    for (let i = effects.particles.length - 1; i >= 0; i--) {
+        const p = effects.particles[i];
+        const t = now - p.born;
+        if (t >= p.ttl) { effects.particles.splice(i, 1); continue; }
+        const px = p.x + p.vx * t;
+        const py = p.y + p.vy * t + 0.00018 * t * t; // subtle downward arc
+        ctx.save();
+        ctx.globalAlpha = 1 - t / p.ttl;
+        ctx.fillStyle = p.color;
+        ctx.shadowColor = p.color;
+        ctx.shadowBlur = 6;
+        ctx.beginPath();
+        ctx.arc(px, py, p.size, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
+    }
+
+    // Score pops (rise + fade).
+    for (let i = effects.scorePops.length - 1; i >= 0; i--) {
+        const s = effects.scorePops[i];
+        const t = (now - s.born) / s.ttl;
+        if (t >= 1) { effects.scorePops.splice(i, 1); continue; }
+        ctx.save();
+        ctx.globalAlpha = 1 - t;
+        ctx.fillStyle = s.color;
+        ctx.font = 'bold 20px Orbitron, monospace';
+        ctx.textAlign = 'center';
+        ctx.shadowColor = s.color;
+        ctx.shadowBlur = 8;
+        ctx.fillText(s.text, s.x, s.y - t * 34);
+        ctx.restore();
+    }
+}
+
+/**
+ * Clear all active effects (e.g. on game start / restart).
+ */
+function resetEffects() {
+    effects.particles.length = 0;
+    effects.ripples.length = 0;
+    effects.scorePops.length = 0;
+    effects.shake = { until: 0, magnitude: 0, duration: 1 };
+}
+
+// Expose for Node/Vitest only (no-op in the browser classic-script context).
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        effects,
+        spawnFoodBurst,
+        spawnScorePop,
+        triggerShake,
+        getShakeOffset,
+        updateAndDrawEffects,
+        resetEffects
+    };
+}

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -15,8 +15,9 @@ function initializeDesktopGame() {
     }
     
     ctx = canvas.getContext('2d');
-    canvas.width = gameConfig.boardSize.width;
-    canvas.height = gameConfig.boardSize.height;
+    setupHiDPICanvas();
+    // Re-scale if the window moves to a screen with a different pixel ratio.
+    window.addEventListener('resize', () => { setupHiDPICanvas(); renderGame(); });
 
     generateNewSession();
     setupKeyboardControls();
@@ -28,6 +29,22 @@ function initializeDesktopGame() {
     if (muteBtn) muteBtn.addEventListener('click', toggleMute);
 
     startGameLoop();
+}
+
+/**
+ * Sizes the canvas backing store to the device pixel ratio so rendering is crisp on
+ * HiDPI / retina screens, while keeping the logical drawing coordinate system at
+ * gameConfig.boardSize (600x600). CSS controls the on-screen display size, so all
+ * game math stays in logical pixels — only the resolution of the buffer changes.
+ */
+function setupHiDPICanvas() {
+    if (!canvas || !ctx) return;
+    const dpr = window.devicePixelRatio || 1;
+    const { width, height } = gameConfig.boardSize;
+    canvas.width = Math.round(width * dpr);
+    canvas.height = Math.round(height * dpr);
+    // Draw in logical (CSS-pixel) coordinates; this transform scales to the buffer.
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 }
 
 // Maps keyboard keys to direction vectors (screen coords: +y is down).
@@ -119,12 +136,16 @@ function startGame() {
     gameState.joystickInput = { x: 0, y: 0 };
     gameState.frameCount = 0;
     gameState.lastMoveTime = performance.now();
-    
+    gameState.combo = 0;
+    gameState.lastFoodTime = 0;
+    resetEffects();
+    updateComboDisplay();
+
     const gameOverScreen = document.getElementById('game-over');
     if (gameOverScreen) {
         gameOverScreen.classList.add('hidden');
     }
-    
+
     updateGameStateInFirebase();
 }
 
@@ -150,16 +171,20 @@ function restartGame() {
         lastMoveTime: performance.now(),
         currentState: GameState.PLAYING,
         joystickInput: { x: 0, y: 0 },
-        frameCount: 0
+        frameCount: 0,
+        combo: 0,
+        lastFoodTime: 0
     };
-    
+
     updateScore();
-    
+    resetEffects();
+    updateComboDisplay();
+
     const gameOverScreen = document.getElementById('game-over');
     if (gameOverScreen) {
         gameOverScreen.classList.add('hidden');
     }
-    
+
     generateFood();
     updateGameStateInFirebase();
 }
@@ -174,16 +199,22 @@ function updateGame(currentTime) {
     const moveDeltaTime = currentTime - gameState.lastMoveTime;
     
     if (gameState.currentState === GameState.PLAYING) {
-        // Always update direction smoothly
-        updateSnakeDirection();
+        // Always update direction smoothly (frame-rate-independent; needs elapsed time)
+        updateSnakeDirection(deltaTime);
         
         // CONSTANT MOVEMENT: Snake moves every frame regardless of joystick input
         if (moveDeltaTime >= gameConfig.movementUpdateMs) {
             moveSnake();
             gameState.lastMoveTime = currentTime;
         }
-        
+
         gameState.frameCount++;
+
+        // Expire a stale combo so the badge clears if you dawdle between bites.
+        if (gameState.combo > 0 && Date.now() - gameState.lastFoodTime > gameConfig.comboWindowMs) {
+            gameState.combo = 0;
+            updateComboDisplay();
+        }
     }
     
     renderGame();
@@ -194,15 +225,32 @@ function updateGame(currentTime) {
     }
 }
 
+// Frame-rate-independent turning: turnSpeed is calibrated per 60fps frame, so we
+// scale each frame's turn by how long it actually took. Clamp protects against a
+// huge jump after the tab is backgrounded (deltaTime can spike to seconds).
+const TARGET_FRAME_MS = 1000 / 60;
+const MAX_FRAME_STEP = 3;
+
 /**
- * Eases the snake logic towards the target rotation from the joystick
+ * Eases the snake heading toward the joystick target. The per-frame turn step is
+ * made frame-rate-independent (so 60 / 120 / 144Hz feel identical) and coupled to
+ * speed (so the turn radius stays ~constant as the snake speeds up). See
+ * logic.js:speedToTurnStep.
+ * @param {number} deltaTime - ms elapsed since the previous frame.
  */
-function updateSnakeDirection() {
-    // Smoothly interpolate the heading toward the joystick target (see logic.js).
+function updateSnakeDirection(deltaTime) {
+    const frameFactor = Math.min(deltaTime / TARGET_FRAME_MS, MAX_FRAME_STEP);
+    const turnStep = speedToTurnStep(
+        gameConfig.turnSpeed,
+        gameState.currentSpeed,
+        gameConfig.baseSpeed,
+        frameFactor,
+        gameConfig.maxTurnSpeedFactor
+    );
     gameState.direction = stepDirection(
         gameState.direction,
         gameState.targetDirection,
-        gameConfig.turnSpeed
+        turnStep
     );
 }
 
@@ -239,19 +287,36 @@ function moveSnake() {
 
     // Food collision detection
     if (eatsFood(head, gameState.food, gameConfig)) {
-        console.log('🍎 Food collected! Score:', gameState.score + 10);
-        gameState.score += 10;
+        const foodX = gameState.food.x;
+        const foodY = gameState.food.y;
+        const now = Date.now();
+
+        // Combo: eating again within the window extends the streak (capped at maxCombo).
+        gameState.combo = (now - gameState.lastFoodTime < gameConfig.comboWindowMs)
+            ? gameState.combo + 1
+            : 1;
+        gameState.lastFoodTime = now;
+        const multiplier = Math.min(gameState.combo, gameConfig.maxCombo);
+        const gained = 10 * multiplier;
+        gameState.score += gained;
         updateScore();
-        playFoodSound();
+        updateComboDisplay();
+
+        // Juice: particle burst + ripple + floating score at the point of the bite.
+        spawnFoodBurst(foodX, foodY, colors.food);
+        spawnScorePop(foodX, foodY,
+            multiplier > 1 ? `+${gained} x${multiplier}` : `+${gained}`,
+            multiplier > 1 ? colors.food : '#ffffff');
+
+        playFoodSound(multiplier); // ascending pitch as the streak climbs
         sendHapticFeedback('food');
         generateFood();
         addSnakeSegment();
-        
+
         // Increase base speed gradually
         if (gameState.baseSpeed < gameConfig.maxSpeed) {
             gameState.baseSpeed = Math.min(gameConfig.maxSpeed, gameState.baseSpeed + gameConfig.speedIncrease);
             gameState.currentSpeed = gameState.baseSpeed; // Update current speed too
-            console.log('⚡ Speed increased to:', gameState.baseSpeed.toFixed(2));
         }
     }
 }
@@ -351,10 +416,17 @@ function generateFood() {
 function renderGame() {
     if (!ctx) return;
     
-    // Clear canvas
+    // Clear canvas (draw in logical coords; the HiDPI transform scales to the buffer)
+    const W = gameConfig.boardSize.width;
+    const H = gameConfig.boardSize.height;
     ctx.fillStyle = colors.background;
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-    
+    ctx.fillRect(0, 0, W, H);
+
+    // Screen-shake: everything below is drawn shifted; the offset decays to zero.
+    const shake = getShakeOffset();
+    ctx.save();
+    ctx.translate(shake.x, shake.y);
+
     // Draw boundary guidelines
     if (gameState.currentState === GameState.PLAYING) {
         ctx.strokeStyle = 'rgba(255, 255, 255, 0.1)';
@@ -425,25 +497,30 @@ function renderGame() {
     
     // Show waiting message
     if (gameState.currentState === GameState.WAITING_FOR_START) {
-        ctx.fillStyle = 'rgba(15, 15, 35, 0.9)';
-        ctx.fillRect(0, 0, canvas.width, canvas.height);
-        
-        const gradient = ctx.createLinearGradient(0, canvas.height / 2 - 40, 0, canvas.height / 2 + 80);
-        gradient.addColorStop(0, '#ff1493');
-        gradient.addColorStop(0.5, '#ff6b35');
-        gradient.addColorStop(1, '#f72585');
-        
+        ctx.fillStyle = 'rgba(10, 10, 16, 0.9)';
+        ctx.fillRect(0, 0, W, H);
+
+        const gradient = ctx.createLinearGradient(0, H / 2 - 40, 0, H / 2 + 80);
+        gradient.addColorStop(0, '#7df9ff');
+        gradient.addColorStop(0.5, '#19c3b2');
+        gradient.addColorStop(1, '#2de2c0');
+
         ctx.fillStyle = gradient;
         ctx.font = 'bold 24px Orbitron, monospace';
         ctx.textAlign = 'center';
-        ctx.shadowColor = '#ff1493';
+        ctx.shadowColor = '#22d3c5';
         ctx.shadowBlur = 10;
-        
-        ctx.fillText('Waiting for Mobile Controller', canvas.width / 2, canvas.height / 2 - 20);
-        ctx.fillText('Snake Moves Continuously - Be Ready!', canvas.width / 2, canvas.height / 2 + 20);
+
+        ctx.fillText('Waiting for Mobile Controller', W / 2, H / 2 - 20);
+        ctx.fillText('Snake Moves Continuously - Be Ready!', W / 2, H / 2 + 20);
         
         ctx.shadowBlur = 0;
     }
+
+    // Draw juice (particles, ripples, score pops) above the board.
+    updateAndDrawEffects(ctx);
+
+    ctx.restore(); // end screen-shake transform
 }
 
 /**
@@ -457,6 +534,22 @@ function updateScore() {
 }
 
 /**
+ * Shows/hides the combo badge over the board. Visible only while a streak (x2+) is
+ * active; reflects the capped multiplier.
+ */
+function updateComboDisplay() {
+    const el = document.getElementById('combo-display');
+    if (!el) return;
+    const multiplier = Math.min(gameState.combo, gameConfig.maxCombo);
+    if (multiplier > 1) {
+        el.textContent = `🔥 x${multiplier}`;
+        el.classList.remove('hidden');
+    } else {
+        el.classList.add('hidden');
+    }
+}
+
+/**
  * Triggers game over GUI modal
  */
 function gameOver() {
@@ -464,6 +557,15 @@ function gameOver() {
     gameState.currentState = GameState.GAME_OVER;
     playCrashSound();
     sendHapticFeedback('crash');
+
+    // Juice: screen shake + a debris burst at the head for crash impact.
+    triggerShake(9, 340);
+    const crashHead = gameState.snake[0];
+    if (crashHead) spawnFoodBurst(crashHead.x, crashHead.y, colors.snakeHead);
+
+    // The streak is over — clear the combo badge.
+    gameState.combo = 0;
+    updateComboDisplay();
 
     const finalScoreElement = document.getElementById('final-score');
     if (finalScoreElement) {
@@ -476,9 +578,11 @@ function gameOver() {
     const newHighEl = document.getElementById('new-high-score');
     if (newHighEl) newHighEl.classList.toggle('hidden', !isNewBest);
 
+    // Hitstop: let the impact register for a beat before the modal slides in. The
+    // snake is already frozen (state = GAME_OVER), so the canvas just keeps shaking.
     const gameOverScreen = document.getElementById('game-over');
     if (gameOverScreen) {
-        gameOverScreen.classList.remove('hidden');
+        setTimeout(() => gameOverScreen.classList.remove('hidden'), 150);
     }
 
     updateGameStateInFirebase();

--- a/public/js/logic.js
+++ b/public/js/logic.js
@@ -48,6 +48,26 @@ function stepDirection(current, target, turnSpeed) {
 }
 
 /**
+ * Effective per-frame turn step — frame-rate-independent and speed-coupled.
+ * - `frameFactor` (= elapsedMs / (1000/60), clamped by the caller) scales the step
+ *   by how long the frame actually took, so angular velocity is identical on 60 /
+ *   120 / 144Hz displays instead of changing with refresh rate.
+ * - The speed term scales the turn rate with how fast the snake is moving (relative
+ *   to `baseSpeed`), so the turn *radius* stays roughly constant as it speeds up —
+ *   the snake stays as maneuverable at full tilt as it is at rest.
+ * @param {number} baseTurn - config.turnSpeed (radians per 60fps frame).
+ * @param {number} currentSpeed - the snake's current speed.
+ * @param {number} baseSpeed - the reference (un-boosted) speed.
+ * @param {number} frameFactor - elapsedMs / (1000/60), pre-clamped by the caller.
+ * @param {number} maxSpeedFactor - upper clamp on the speed multiplier.
+ * @returns {number} the turn step to pass to stepDirection().
+ */
+function speedToTurnStep(baseTurn, currentSpeed, baseSpeed, frameFactor, maxSpeedFactor) {
+    const speedFactor = Math.min(currentSpeed / baseSpeed, maxSpeedFactor);
+    return baseTurn * speedFactor * frameFactor;
+}
+
+/**
  * True if the head has crossed the playable boundary.
  * @param {{x:number,y:number}} head
  * @param {object} config - gameConfig (uses wallMargin, boardSize).
@@ -115,6 +135,7 @@ if (typeof module !== 'undefined' && module.exports) {
         normalizeAngle,
         shortestAngleDelta,
         stepDirection,
+        speedToTurnStep,
         hitsWall,
         hitsSelf,
         eatsFood,

--- a/public/js/sound.js
+++ b/public/js/sound.js
@@ -44,8 +44,13 @@ function playTone(freq, durationMs, type = 'sine', gainValue = 0.3) {
     osc.stop(now + durationMs / 1000);
 }
 
-function playFoodSound() {
-    playTone(660, 110, 'square', 0.28);
+/**
+ * Eat blip. Pitch climbs with the combo step for a satisfying ascending streak.
+ * @param {number} [step=1] - combo multiplier (1 = no combo).
+ */
+function playFoodSound(step = 1) {
+    const freq = 660 * Math.pow(1.06, Math.max(0, step - 1));
+    playTone(freq, 110, 'square', 0.28);
 }
 
 function playCrashSound() {

--- a/public/js/state.js
+++ b/public/js/state.js
@@ -37,7 +37,9 @@ let gameState = {
     lastMoveTime: 0, // For consistent smooth movement timing
     currentState: GameState.WAITING_FOR_START,
     joystickInput: { x: 0, y: 0 },
-    frameCount: 0
+    frameCount: 0,
+    combo: 0,          // Current eat streak (drives the score multiplier)
+    lastFoodTime: 0    // Timestamp of the last food eaten (for the combo window)
 };
 
 // Enhanced session management with better error handling

--- a/public/sw.js
+++ b/public/sw.js
@@ -5,7 +5,7 @@
 // cross-origin traffic (Firebase, gstatic, unpkg, Font Awesome) is intentionally
 // left untouched so realtime sync keeps working. Bump CACHE when shell assets change.
 
-const CACHE = 'snake-shell-v1';
+const CACHE = 'snake-shell-v2';
 
 const SHELL_ASSETS = [
     './',
@@ -21,6 +21,7 @@ const SHELL_ASSETS = [
     './js/state.js',
     './js/leaderboard.js',
     './js/sound.js',
+    './js/effects.js',
     './js/network.js',
     './js/game.js',
     './js/controller.js',

--- a/tests/logic.test.js
+++ b/tests/logic.test.js
@@ -5,6 +5,7 @@ const {
     normalizeAngle,
     shortestAngleDelta,
     stepDirection,
+    speedToTurnStep,
     hitsWall,
     hitsSelf,
     eatsFood,
@@ -71,6 +72,32 @@ describe('stepDirection', () => {
         const d = stepDirection(0.01, -0.5, 0.08); // would go negative before normalizing
         expect(d).toBeGreaterThanOrEqual(0);
         expect(d).toBeLessThan(TAU);
+    });
+});
+
+describe('speedToTurnStep', () => {
+    const BASE_TURN = 0.13;
+    const BASE_SPEED = 2;
+    const MAX_FACTOR = 2.2;
+
+    it('returns the base turn at base speed on a 60fps frame', () => {
+        // frameFactor 1 (= a 60fps frame), currentSpeed == baseSpeed -> no scaling.
+        expect(speedToTurnStep(BASE_TURN, BASE_SPEED, BASE_SPEED, 1, MAX_FACTOR)).toBeCloseTo(BASE_TURN);
+    });
+
+    it('scales the turn rate up with speed (keeps turn radius ~constant)', () => {
+        // Twice the speed -> twice the angular step, so radius = speed/angular stays put.
+        expect(speedToTurnStep(BASE_TURN, 4, BASE_SPEED, 1, MAX_FACTOR)).toBeCloseTo(BASE_TURN * 2);
+    });
+
+    it('clamps the speed multiplier at maxSpeedFactor', () => {
+        expect(speedToTurnStep(BASE_TURN, 100, BASE_SPEED, 1, MAX_FACTOR)).toBeCloseTo(BASE_TURN * MAX_FACTOR);
+    });
+
+    it('is frame-rate independent: a longer frame turns proportionally further', () => {
+        // A frame twice as long (frameFactor 2) turns twice as far -> constant rad/sec.
+        expect(speedToTurnStep(BASE_TURN, BASE_SPEED, BASE_SPEED, 2, MAX_FACTOR)).toBeCloseTo(BASE_TURN * 2);
+        expect(speedToTurnStep(BASE_TURN, BASE_SPEED, BASE_SPEED, 0.5, MAX_FACTOR)).toBeCloseTo(BASE_TURN / 2);
     });
 });
 


### PR DESCRIPTION
## 🎯 Description

A "game-feel" glow-up: makes the snake **play** better and adds GenZ-friendly juice. The
work is grouped into three phases, all **client-side** (no Firebase rules touched).

**Phase A — mechanics (the "feels off" fix).** Two real bugs plus tuning:
- **Frame-rate-independent turning.** `turnSpeed` was applied once *per render frame*, so a
  144Hz display turned ~2.4× faster than 60Hz — control feel changed per device. Turning is
  now time-scaled (new pure helper `logic.js:speedToTurnStep`) so it's identical on any screen.
- **Speed-coupled turn rate.** `turnSpeed` was constant while speed ramped 2→5, so the turn
  *radius* ballooned and late game fought the player. Turn rate now scales with speed → radius
  stays ~constant.
- Crisper base turn (`0.08 → 0.13`), 30 Hz joystick input (throttle `50 → 33 ms`), gentler
  difficulty (`speedIncrease 0.1 → 0.06`, `maxSpeed 5 → 4`).

**Phase B — crisp & cohesive visuals.**
- **HiDPI canvas** — backing store scaled by `devicePixelRatio` (kills retina/phone blur);
  logical 600×600 drawing space unchanged.
- **Unified palette** — canvas now uses the teal brand (teal/cyan snake, gold food) so board
  and UI read as one design.
- **Desktop controls legend** so keyboard play is discoverable.

**Phase C — juice + combo.**
- New `effects.js`: particle burst + ripple on eat, floating "+N" score pops, screen shake +
  hitstop on crash — all frame-rate independent.
- **Combo/streak system**: quick successive eats build a capped multiplier that scales score
  and raises the eat-sound pitch; a streak badge floats over the board.
- Bumped the service-worker cache to `v2` so the deploy ships fresh assets.

## 🎮 Type of Change
- [x] 🐛 Bug fix (frame-rate-dependent turning)
- [x] ✨ New feature (juice, combo system, HiDPI, palette, controls legend)

## 🧪 Testing

**Honest scope:** this machine has **no Node** (see the `dev-environment` project memory), so
`npm run lint` / `npm test` were **not** run locally — CI runs them (lint/test are currently
non-blocking). Everything below was verified in-browser via a local `python -m http.server` +
the Claude_Preview MCP, asserting on the DOM / `eval` (screenshots time out here because of the
perpetual canvas + CSS animations, so DOM assertions were used instead).

### Verified (desktop, via eval):
- **Frame-rate independence**: two 16.67 ms frames and one 33.33 ms frame converge to the
  identical heading (the bug is gone).
- **Speed coupling**: doubling speed doubles the per-frame turn step (radius held constant).
- **HiDPI**: canvas backing store = `600 × devicePixelRatio`; logical draw space unchanged.
- **Palette**: snake `#19c3b2`, head `#7df9ff`, food `#ffcf4d` applied.
- **Effects**: a burst spawns 10 particles + 1 ripple and drains; shake activates then decays.
- **Combo eat-path** (driving the real `moveSnake()`): 1st eat → score 10 / combo ×1; 2nd eat →
  score **30** / combo ×2; ascending eat-pitch doesn't throw; streak badge styles apply.
- **Zero console errors** on a clean load.

### Not re-tested (unchanged paths, no device on hand):
- Mobile controller / Firebase cross-device / QR pairing. Note the joystick **throttle changed
  50 → 33 ms** (higher input rate); logic path is unchanged but it wasn't exercised on a phone.

### Reproduce:
1. `python -m http.server 8000 --directory public`, open `http://localhost:8000`.
2. Press **Space**, steer with arrows/WASD — turns are crisper and consistent.
3. Eat several foods quickly to build a 🔥 combo; crash to see shake + debris.
4. `?session=123456` in a second tab forces the phone/controller view.

## 📋 Checklist
- [x] Code follows the project's style (vanilla classic-script architecture preserved)
- [x] Performed a self-review of the diff
- [x] Commented the non-obvious areas (turn math, HiDPI, effects)
- [x] Added a unit test for the new pure helper (`speedToTurnStep`)
- [ ] Ran unit tests locally — **not run** (no Node on this machine; CI runs them)

## 🎮 Game-Specific Testing (verified via eval)
- [x] Snake moves continuously without stopping
- [x] Joystick/keyboard controls direction smoothly
- [x] Score updates properly (now scales with combo multiplier)
- [x] Game over detection works (now with shake + hitstop)

## 🔧 Breaking Changes
- [x] No breaking API changes. **Behavior changes worth noting:** scores now scale with the
  combo multiplier (high scores will be larger), and the canvas palette changed (teal/cyan +
  gold). Both are intentional and visual/feel — worth an eyeball on the live site.

## 🚀 Deployment Notes
- [x] No special deployment needed — **hosting-only**. Touches `public/` only; **no Firebase
  rule changes** (`firestore.rules` / `database.rules.json` untouched). Merging to `master`
  auto-deploys hosting via CI. The SW cache bump (`v1 → v2`) ensures clients pull fresh assets.

---

**Notes for the reviewer:** the palette and the "feel" are subjective — best judged by playing
the deployed build. Tuning values (`turnSpeed`, `comboWindowMs`, `maxCombo`, shake magnitude)
all live in `config.js` / `effects.js` and are easy to nudge.
