### PR TITLE
feat(ui): shareable game-over card; remove controls hint; fix QR overflow

### DIFF
--- a/public/css/desktop.css
+++ b/public/css/desktop.css
@@ -36,7 +36,9 @@
 .desktop-view {
     display: none;
     height: 100vh;
-    overflow: hidden;
+    /* Scroll safety-net: never permanently clip the connection card / QR off-screen. */
+    overflow-y: auto;
+    overflow-x: hidden;
 }
 
 .desktop-container {
@@ -274,10 +276,10 @@
 }
 
 .restart-prompt {
-    color: var(--color-teal-600);
-    font-size: var(--font-size-lg);
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
     font-weight: var(--font-weight-medium);
-    margin-top: var(--space-10);
+    margin-top: var(--space-12);
 }
 
 /* Control Panel */
@@ -324,14 +326,14 @@
     background: linear-gradient(135deg, rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.08), rgba(var(--color-teal-700-rgb, var(--color-teal-700)), 0.08));
     backdrop-filter: blur(15px);
     border-radius: var(--radius-lg);
-    padding: var(--space-32);
+    padding: var(--space-20);
     border: 1px solid rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.3);
     text-align: center;
     box-shadow: var(--shadow-md);
 }
 
 .session-code {
-    margin: var(--space-24) 0;
+    margin: var(--space-12) 0;
 }
 
 .code-label {
@@ -355,7 +357,7 @@
 }
 
 .qr-container {
-    margin: var(--space-32) 0;
+    margin: var(--space-16) 0;
     display: flex;
     justify-content: center;
 }
@@ -429,7 +431,9 @@
     }
     
     #game-canvas {
+        width: auto;
         max-width: 100%;
+        max-height: 60vh;
         height: auto;
     }
 }
@@ -485,28 +489,6 @@
     text-shadow: 0 0 8px rgba(255, 209, 102, 0.6);
 }
 
-/* Desktop controls legend — tells the host they can play keyboard-only. */
-.controls-hint {
-    margin: 0;
-    width: 100%;
-    text-align: center;
-    color: var(--color-text-secondary);
-    font-size: var(--font-size-sm);
-    line-height: var(--line-height-normal);
-}
-
-.controls-hint kbd {
-    display: inline-block;
-    font-family: var(--font-family-mono);
-    font-size: var(--font-size-xs);
-    color: var(--color-primary);
-    background: rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.12);
-    border: 1px solid rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.4);
-    border-radius: var(--radius-sm);
-    padding: 1px 6px;
-    margin: 0 2px;
-}
-
 /* Combo streak badge — floats over the top-right of the board during a streak. */
 .combo-display {
     position: absolute;
@@ -529,4 +511,85 @@
 @keyframes comboPop {
     0% { transform: scale(0.6); opacity: 0; }
     100% { transform: scale(1); opacity: 1; }
+}
+
+/* ── Game-over share card ───────────────────────────────────────────── */
+.share-section {
+    margin-top: var(--space-24);
+}
+
+.share-prompt {
+    margin: 0 0 var(--space-12);
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+}
+
+.share-buttons {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: var(--space-12);
+}
+
+/* Reuses the .social-link base (circular 45px gradient + hover shimmer), in teal. */
+.share-btn {
+    background: linear-gradient(45deg, var(--color-teal-700), var(--color-primary));
+    color: var(--color-surface);
+    box-shadow: var(--shadow-md);
+    border: none;
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.share-btn:hover {
+    background: linear-gradient(45deg, var(--color-primary), var(--color-teal-700));
+    transform: translateY(-3px) scale(1.05);
+    box-shadow: var(--shadow-lg);
+}
+
+.btn-play-again {
+    margin-top: var(--space-24);
+    padding: var(--space-12) var(--space-32);
+    font-family: 'Orbitron', var(--font-family-base);
+    font-size: var(--font-size-lg);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-btn-primary-text);
+    background: linear-gradient(45deg, var(--color-primary), var(--color-teal-600));
+    border: none;
+    border-radius: var(--radius-full);
+    cursor: pointer;
+    box-shadow: 0 0 20px rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.5);
+    transition: all var(--duration-normal) var(--ease-standard);
+}
+
+.btn-play-again:hover {
+    transform: translateY(-2px) scale(1.04);
+    box-shadow: 0 0 30px rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.7);
+}
+
+/* Share feedback toast (e.g. the Instagram copy fallback). */
+.toast {
+    position: fixed;
+    bottom: var(--space-24);
+    left: 50%;
+    transform: translateX(-50%) translateY(20px);
+    background: var(--color-surface);
+    color: var(--color-text);
+    border: 1px solid rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.5);
+    padding: var(--space-12) var(--space-20);
+    border-radius: var(--radius-full);
+    box-shadow: var(--shadow-lg);
+    font-size: var(--font-size-sm);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--duration-normal) var(--ease-standard),
+                transform var(--duration-normal) var(--ease-standard);
+    z-index: 10000;
+}
+
+.toast--visible {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
 }

--- a/public/index.html
+++ b/public/index.html
@@ -121,7 +121,19 @@
                                 <span id="final-score" class="score-value">0</span>
                             </div>
                             <p id="new-high-score" class="new-high-score hidden">🏆 New High Score!</p>
-                            <p class="restart-prompt">Press Space or use your phone to play again</p>
+
+                            <div class="share-section">
+                                <p class="share-prompt">Flex your score</p>
+                                <div class="share-buttons">
+                                    <button class="social-link share-btn share-whatsapp" type="button" data-share="whatsapp" aria-label="Share on WhatsApp"><i class="fab fa-whatsapp"></i></button>
+                                    <button class="social-link share-btn share-x" type="button" data-share="x" aria-label="Share on X"><i class="fab fa-x-twitter"></i></button>
+                                    <button class="social-link share-btn share-facebook" type="button" data-share="facebook" aria-label="Share on Facebook"><i class="fab fa-facebook-f"></i></button>
+                                    <button class="social-link share-btn share-instagram" type="button" data-share="instagram" aria-label="Share on Instagram"><i class="fab fa-instagram"></i></button>
+                                </div>
+                            </div>
+
+                            <button id="play-again-btn" class="btn-play-again" type="button">Play Again</button>
+                            <p class="restart-prompt">or press Space · use your phone</p>
                         </div>
                     </div>
                 </div>
@@ -137,10 +149,6 @@
                             <span id="high-score" class="score-value">0</span>
                         </div>
                     </div>
-
-                    <p class="controls-hint">
-                        <kbd>Space</kbd> start · <kbd>↑ ↓ ← →</kbd> / <kbd>WASD</kbd> steer · or 📱 scan to play from your phone
-                    </p>
 
                     <div class="connection-card">
                         <div class="session-code">
@@ -214,6 +222,7 @@
     <script src="js/effects.js"></script>
     <script src="js/network.js"></script>
     <script src="js/game.js"></script>
+    <script src="js/share.js"></script>
     <script src="js/controller.js"></script>
     <script src="js/main.js"></script>
     

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -28,6 +28,9 @@ function initializeDesktopGame() {
     const muteBtn = document.getElementById('mute-btn');
     if (muteBtn) muteBtn.addEventListener('click', toggleMute);
 
+    // Game-over share card + Play Again button (share.js).
+    if (typeof wireGameOverCard === 'function') wireGameOverCard();
+
     startGameLoop();
 }
 

--- a/public/js/share.js
+++ b/public/js/share.js
@@ -1,0 +1,99 @@
+// ==========================================
+// SHARE-SCORE CARD — game-over social sharing
+// ==========================================
+// Wires the game-over card's share buttons (WhatsApp / X / Facebook / Instagram)
+// and the "Play Again" button. Text + link sharing via each network's web intent;
+// Instagram (which has no web text-share) uses the native share sheet when present,
+// otherwise copies the caption and opens instagram.com. The score is read live from
+// gameState at click time. Loaded after game.js (needs restartGame) and
+// leaderboard.js (getHighScore); kept separate so game.js stays small.
+
+/** Base game URL to share (no session param). */
+function shareUrl() {
+    return `${location.origin}${location.pathname}`;
+}
+
+/** Caption for the score, with a "(new best!)" flourish when it ties/beats the best. */
+function buildShareText(score) {
+    const best = (typeof getHighScore === 'function') ? getHighScore() : 0;
+    const flair = (score > 0 && score >= best) ? ' (new best!)' : '';
+    return `I scored ${score} on Snake 🐍🔥${flair} — can you beat me?`;
+}
+
+/** Small transient toast for share feedback (e.g. the Instagram copy fallback). */
+function showToast(message) {
+    let toast = document.getElementById('share-toast');
+    if (!toast) {
+        toast = document.createElement('div');
+        toast.id = 'share-toast';
+        toast.className = 'toast';
+        document.body.appendChild(toast);
+    }
+    toast.textContent = message;
+    toast.classList.add('toast--visible');
+    clearTimeout(toast._hideTimer);
+    toast._hideTimer = setTimeout(() => toast.classList.remove('toast--visible'), 2600);
+}
+
+/** Open a popup window for a web share intent. */
+function openShareWindow(url) {
+    window.open(url, '_blank', 'noopener,noreferrer,width=600,height=520');
+}
+
+/** Instagram has no web text-share: use the native sheet, else copy caption + open IG. */
+function shareToInstagram(text, url) {
+    if (navigator.share) {
+        navigator.share({ text, url }).catch(() => {});
+        return;
+    }
+    const caption = `${text} ${url}`;
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(caption)
+            .then(() => showToast('Caption copied — paste it into your Instagram story!'))
+            .catch(() => showToast('Copy your score to share on Instagram'));
+    } else {
+        showToast('Copy your score to share on Instagram');
+    }
+    window.open('https://www.instagram.com/', '_blank', 'noopener,noreferrer');
+}
+
+/** Route a share button to its network's web intent. */
+function openShare(network) {
+    const score = (typeof gameState !== 'undefined' && gameState) ? gameState.score : 0;
+    const text = buildShareText(score);
+    const url = shareUrl();
+    const t = encodeURIComponent(text);
+    const u = encodeURIComponent(url);
+
+    switch (network) {
+        case 'whatsapp':
+            openShareWindow(`https://wa.me/?text=${encodeURIComponent(text + ' ' + url)}`);
+            break;
+        case 'x':
+            openShareWindow(`https://twitter.com/intent/tweet?text=${t}&url=${u}`);
+            break;
+        case 'facebook':
+            // Facebook's sharer only shares the link; it ignores prefilled text.
+            openShareWindow(`https://www.facebook.com/sharer/sharer.php?u=${u}`);
+            break;
+        case 'instagram':
+            shareToInstagram(text, url);
+            break;
+    }
+}
+
+/** Attach handlers for the game-over card's share + Play Again buttons (call once). */
+function wireGameOverCard() {
+    document.querySelectorAll('[data-share]').forEach((btn) => {
+        btn.addEventListener('click', () => openShare(btn.getAttribute('data-share')));
+    });
+    const playAgain = document.getElementById('play-again-btn');
+    if (playAgain && typeof restartGame === 'function') {
+        playAgain.addEventListener('click', () => restartGame());
+    }
+}
+
+// Expose for Node/Vitest only (no-op in the browser classic-script context).
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { shareUrl, buildShareText, openShare, wireGameOverCard };
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -5,7 +5,7 @@
 // cross-origin traffic (Firebase, gstatic, unpkg, Font Awesome) is intentionally
 // left untouched so realtime sync keeps working. Bump CACHE when shell assets change.
 
-const CACHE = 'snake-shell-v2';
+const CACHE = 'snake-shell-v3';
 
 const SHELL_ASSETS = [
     './',
@@ -24,6 +24,7 @@ const SHELL_ASSETS = [
     './js/effects.js',
     './js/network.js',
     './js/game.js',
+    './js/share.js',
     './js/controller.js',
     './js/main.js',
     './snake-logo.png',


### PR DESCRIPTION
## 🎯 Description

Three desktop UX fixes requested against the live build:

1. **Shareable game-over card.** The game-over modal now has a "Flex your score" row with
   **WhatsApp / X / Facebook / Instagram** buttons plus a primary **Play Again** button. Sharing is
   **text + link** via each network's web intent ("I scored 347 on Snake 🐍🔥 (new best!) — can you
   beat me? <link>"); Facebook shares the link (its sharer ignores prefilled text). **Instagram**
   (no web text-share) uses the native share sheet on phones, else copies the caption and opens
   instagram.com with a small toast. All logic is isolated in a **new small `public/js/share.js`**
   so `game.js` only gains one wiring line; the buttons reuse the existing `.social-link` teal style.
2. **Removed the keyboard controls hint** line that was added last pass.
3. **Fixed the QR / connection card overflowing off-screen** on short/narrow windows: `.desktop-view`
   now scrolls as a safety-net, the board is capped at `60vh` (kept square via `width:auto` +
   `aspect-ratio`) on small screens, and the connection-card padding/margins are trimmed.

## 🎮 Type of Change
- [x] ✨ New feature (game-over share card + Play Again)
- [x] 🐛 Bug fix (QR/connection card overflow)
- [x] 🔧 Refactor/cleanup (removed the controls hint; share logic kept in its own small module)

## 🧪 Testing

No Node on this machine (see the `dev-environment` memory), so `npm`/Vitest were **not** run locally
— CI runs them. Verified in-browser via `python -m http.server` + the Claude_Preview MCP, asserting
on the DOM/`eval` (screenshots time out here; the service worker was cleared between checks).

**Verified:**
- **Share intents** — stubbing `window.open`, each button opens the correct prefilled target:
  WhatsApp `wa.me/?text=…`, X `twitter.com/intent/tweet?text=…&url=…`, Facebook
  `sharer.php?u=…`; Instagram (no `navigator.share` on desktop) falls back to copy + open IG.
  The caption carries the live score and a "(new best!)" flag.
- **Play Again** — clicking it calls `restartGame()`: state `game_over → playing`, modal hidden.
- **Controls hint** — element removed from the DOM.
- **Overflow fix** — at 900×680 the board renders **408×408 square** (capped at 60vh), `.desktop-view`
  is `overflow-y:auto` and scrollable, and the connection card/QR is fully reachable; at 1400×900 the
  board is back to a full **600×600 square** (no regression).
- **Share buttons** are teal-gradient circular (reuse `.social-link`); **zero console errors**.

**Reproduce:**
1. `python -m http.server 8000 --directory public`, open `http://localhost:8000`.
2. Play, crash → the game-over card shows share buttons + Play Again.
3. Click a share button → the prefilled share target opens; click Play Again → new game.
4. Shrink the window → the board scales down and the QR stays reachable (scroll if needed).

## 📋 Checklist
- [x] Follows the project's vanilla classic-script architecture (new `share.js` in load order; SW cache bumped to v3)
- [x] Self-reviewed the diff
- [x] Kept files small/readable — share logic isolated in `share.js`; `game.js` +1 wiring line
- [x] Commented the non-obvious bits (Instagram fallback, FB link-only sharing)
- [ ] Ran unit tests locally — **not run** (no Node; CI runs them). No existing tests were touched.

## 🔧 Breaking Changes
- [x] No breaking changes. Pure desktop UI: new share card, hint removed, overflow fixed.

## 🚀 Deployment Notes
- [x] No special deployment needed — **hosting-only**. Touches `public/` only; **no Firebase rule
  changes**. Merging to `master` auto-deploys hosting. SW cache bumped (`v2 → v3`) so clients pull
  fresh assets including the new `share.js`.

---

**Note:** generated-image ("flex card") sharing was intentionally deferred — text + link was chosen
for simplicity and small footprint, per the agreed scope.
