### PR TITLE
feat(mobile): move share card to the phone; fix X icon; shrink desktop header

### DIFF
--- a/public/css/desktop.css
+++ b/public/css/desktop.css
@@ -67,7 +67,7 @@
 
 .game-title {
     font-family: 'Orbitron', var(--font-family-base);
-    font-size: var(--font-size-4xl);
+    font-size: var(--font-size-3xl);
     font-weight: var(--font-weight-bold);
     background: linear-gradient(45deg, var(--color-primary), var(--color-warning), var(--color-teal-600), var(--color-teal-700));
     background-size: 400% 400%;
@@ -87,7 +87,7 @@
 
 .creator-text {
     color: var(--color-warning);
-    font-size: var(--font-size-lg);
+    font-size: var(--font-size-base);
     font-weight: var(--font-weight-medium);
     margin-top: var(--space-4);
     text-shadow: 0 0 5px rgba(var(--color-warning-rgb, var(--color-orange-500-rgb)), 0.5);
@@ -96,12 +96,12 @@
 .title-with-logo {
     display: flex;
     align-items: center;
-    gap: var(--space-20);
+    gap: var(--space-16);
 }
 
 .game-logo {
-    width: 80px;
-    height: 80px;
+    width: 56px;
+    height: 56px;
     border-radius: var(--radius-full);
     box-shadow: 
         0 0 30px rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.5),
@@ -513,83 +513,9 @@
     100% { transform: scale(1); opacity: 1; }
 }
 
-/* ── Game-over share card ───────────────────────────────────────────── */
-.share-section {
-    margin-top: var(--space-24);
-}
-
-.share-prompt {
-    margin: 0 0 var(--space-12);
-    color: var(--color-text-secondary);
-    font-size: var(--font-size-sm);
-    text-transform: uppercase;
-    letter-spacing: 0.12em;
-}
-
-.share-buttons {
-    display: flex;
-    justify-content: center;
-    flex-wrap: wrap;
-    gap: var(--space-12);
-}
-
-/* Reuses the .social-link base (circular 45px gradient + hover shimmer), in teal. */
-.share-btn {
-    background: linear-gradient(45deg, var(--color-teal-700), var(--color-primary));
-    color: var(--color-surface);
-    box-shadow: var(--shadow-md);
-    border: none;
-    cursor: pointer;
-    font-family: inherit;
-}
-
-.share-btn:hover {
-    background: linear-gradient(45deg, var(--color-primary), var(--color-teal-700));
-    transform: translateY(-3px) scale(1.05);
-    box-shadow: var(--shadow-lg);
-}
-
-.btn-play-again {
-    margin-top: var(--space-24);
-    padding: var(--space-12) var(--space-32);
-    font-family: 'Orbitron', var(--font-family-base);
-    font-size: var(--font-size-lg);
-    font-weight: var(--font-weight-bold);
-    color: var(--color-btn-primary-text);
-    background: linear-gradient(45deg, var(--color-primary), var(--color-teal-600));
-    border: none;
-    border-radius: var(--radius-full);
-    cursor: pointer;
-    box-shadow: 0 0 20px rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.5);
-    transition: all var(--duration-normal) var(--ease-standard);
-}
-
-.btn-play-again:hover {
-    transform: translateY(-2px) scale(1.04);
-    box-shadow: 0 0 30px rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.7);
-}
-
-/* Share feedback toast (e.g. the Instagram copy fallback). */
-.toast {
-    position: fixed;
-    bottom: var(--space-24);
-    left: 50%;
-    transform: translateX(-50%) translateY(20px);
-    background: var(--color-surface);
-    color: var(--color-text);
-    border: 1px solid rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.5);
-    padding: var(--space-12) var(--space-20);
-    border-radius: var(--radius-full);
-    box-shadow: var(--shadow-lg);
-    font-size: var(--font-size-sm);
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity var(--duration-normal) var(--ease-standard),
-                transform var(--duration-normal) var(--ease-standard);
-    z-index: 10000;
-}
-
-.toast--visible {
-    opacity: 1;
-    transform: translateX(-50%) translateY(0);
+/* Shrink the header on smaller laptops so it stays proportionate. */
+@media (max-width: 1024px) {
+    .game-logo { width: 48px; height: 48px; }
+    .game-title { font-size: var(--font-size-2xl); }
+    .creator-text { font-size: var(--font-size-sm); }
 }

--- a/public/css/mobile.css
+++ b/public/css/mobile.css
@@ -296,8 +296,166 @@
         max-width: 100px;
         max-height: 100px;
     }
-    
+
     .center-icon {
         font-size: 4vw;
     }
+}
+
+/* ── Mobile game-over share card ─────────────────────────────────────── */
+.mobile-game-over {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 6vh 6vw;
+    background: linear-gradient(135deg, rgba(10, 10, 16, 0.92), rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.10));
+    backdrop-filter: blur(8px);
+    z-index: 50;
+}
+
+.mobile-game-over.hidden {
+    display: none;
+}
+
+.mobile-game-over-content {
+    width: 100%;
+    max-width: 420px;
+    text-align: center;
+    background: linear-gradient(135deg, rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.14), rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.05));
+    border: 1px solid rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.4);
+    border-radius: var(--radius-lg);
+    padding: 5vh var(--space-24);
+    box-shadow: var(--shadow-lg);
+}
+
+.mobile-go-title {
+    font-family: 'Orbitron', var(--font-family-base);
+    color: var(--color-primary);
+    font-size: var(--font-size-4xl);
+    margin: 0 0 var(--space-16);
+    text-shadow: 0 0 20px rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.8);
+}
+
+.mobile-score {
+    margin-bottom: var(--space-24);
+}
+
+.mobile-score-label {
+    display: block;
+    color: var(--color-warning);
+    font-size: var(--font-size-sm);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin-bottom: var(--space-4);
+}
+
+.mobile-score-value {
+    font-family: 'Orbitron', var(--font-family-base);
+    color: var(--color-primary);
+    font-size: 3rem;
+    font-weight: var(--font-weight-bold);
+    text-shadow: 0 0 12px rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.7);
+}
+
+.share-prompt {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    margin: 0 0 var(--space-12);
+}
+
+.share-buttons {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: var(--space-16);
+    margin-bottom: var(--space-24);
+}
+
+.share-btn {
+    width: 56px;
+    height: 56px;
+    border-radius: var(--radius-full);
+    border: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: var(--font-size-2xl);
+    color: var(--color-surface);
+    background: linear-gradient(45deg, var(--color-teal-700), var(--color-primary));
+    box-shadow: var(--shadow-md);
+    transition: transform var(--duration-fast) var(--ease-standard);
+}
+
+.share-btn:active {
+    transform: scale(0.92);
+}
+
+.btn-play-again {
+    width: 100%;
+    padding: var(--space-16) var(--space-32);
+    font-family: 'Orbitron', var(--font-family-base);
+    font-size: var(--font-size-xl);
+    font-weight: var(--font-weight-bold);
+    color: var(--color-btn-primary-text);
+    background: linear-gradient(45deg, var(--color-primary), var(--color-teal-600));
+    border: none;
+    border-radius: var(--radius-full);
+    cursor: pointer;
+    box-shadow: 0 0 20px rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.5);
+}
+
+.btn-play-again:active {
+    transform: scale(0.97);
+}
+
+/* Share feedback toast (Instagram copy fallback). */
+.toast {
+    position: fixed;
+    bottom: var(--space-24);
+    left: 50%;
+    transform: translateX(-50%) translateY(20px);
+    background: var(--color-surface);
+    color: var(--color-text);
+    border: 1px solid rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.5);
+    padding: var(--space-12) var(--space-20);
+    border-radius: var(--radius-full);
+    box-shadow: var(--shadow-lg);
+    font-size: var(--font-size-sm);
+    max-width: 90vw;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--duration-normal) var(--ease-standard),
+                transform var(--duration-normal) var(--ease-standard);
+    z-index: 10000;
+}
+
+.toast--visible {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+}
+
+@media (max-width: 480px) {
+    .mobile-go-title { font-size: var(--font-size-3xl); }
+    .mobile-score-value { font-size: 2.5rem; }
+    .share-btn { width: 48px; height: 48px; font-size: var(--font-size-xl); }
+    .share-buttons { gap: var(--space-12); }
+}
+
+@media (max-height: 500px) and (orientation: landscape) {
+    .mobile-game-over { padding: 4vh 8vw; }
+    .mobile-game-over-content { max-width: 540px; padding: var(--space-16) var(--space-24); }
+    .mobile-go-title { font-size: var(--font-size-2xl); margin-bottom: var(--space-8); }
+    .mobile-score { margin-bottom: var(--space-12); }
+    .mobile-score-value { font-size: 2rem; }
+    .share-buttons { margin-bottom: var(--space-12); gap: var(--space-12); }
+    .share-btn { width: 44px; height: 44px; font-size: var(--font-size-lg); }
+    .btn-play-again { padding: var(--space-12) var(--space-24); font-size: var(--font-size-lg); }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,7 @@
     <script src="https://unpkg.com/qrious@4.0.2/dist/qrious.min.js"></script>
     
     <!-- Font Awesome for social icons -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css">
     
     <!-- Override CSS Media Queries -->
     <style>
@@ -121,19 +121,7 @@
                                 <span id="final-score" class="score-value">0</span>
                             </div>
                             <p id="new-high-score" class="new-high-score hidden">🏆 New High Score!</p>
-
-                            <div class="share-section">
-                                <p class="share-prompt">Flex your score</p>
-                                <div class="share-buttons">
-                                    <button class="social-link share-btn share-whatsapp" type="button" data-share="whatsapp" aria-label="Share on WhatsApp"><i class="fab fa-whatsapp"></i></button>
-                                    <button class="social-link share-btn share-x" type="button" data-share="x" aria-label="Share on X"><i class="fab fa-x-twitter"></i></button>
-                                    <button class="social-link share-btn share-facebook" type="button" data-share="facebook" aria-label="Share on Facebook"><i class="fab fa-facebook-f"></i></button>
-                                    <button class="social-link share-btn share-instagram" type="button" data-share="instagram" aria-label="Share on Instagram"><i class="fab fa-instagram"></i></button>
-                                </div>
-                            </div>
-
-                            <button id="play-again-btn" class="btn-play-again" type="button">Play Again</button>
-                            <p class="restart-prompt">or press Space · use your phone</p>
+                            <p class="restart-prompt">Press Space to play again · or use your phone</p>
                         </div>
                     </div>
                 </div>
@@ -208,6 +196,25 @@
                         <span class="center-icon">▶</span>
                     </button>
                 </div>
+            </div>
+        </div>
+
+        <!-- Game-over share card (shown on the phone when the game ends) -->
+        <div id="mobile-game-over" class="mobile-game-over hidden">
+            <div class="mobile-game-over-content">
+                <h2 class="mobile-go-title">Game Over!</h2>
+                <div class="mobile-score">
+                    <span class="mobile-score-label">Score</span>
+                    <span id="mobile-final-score" class="mobile-score-value">0</span>
+                </div>
+                <p class="share-prompt">Flex your score</p>
+                <div class="share-buttons">
+                    <button class="share-btn" type="button" data-share="whatsapp" aria-label="Share on WhatsApp"><i class="fab fa-whatsapp"></i></button>
+                    <button class="share-btn" type="button" data-share="x" aria-label="Share on X"><i class="fab fa-x-twitter"></i></button>
+                    <button class="share-btn" type="button" data-share="facebook" aria-label="Share on Facebook"><i class="fab fa-facebook-f"></i></button>
+                    <button class="share-btn" type="button" data-share="instagram" aria-label="Share on Instagram"><i class="fab fa-instagram"></i></button>
+                </div>
+                <button id="play-again-btn" class="btn-play-again" type="button">Play Again</button>
             </div>
         </div>
     </div>

--- a/public/js/controller.js
+++ b/public/js/controller.js
@@ -62,6 +62,9 @@ function setupMobileEventListeners() {
             centerBtn.classList.remove('active');
         });
     }
+
+    // Wire the game-over share card buttons (share.js): share intents + Play Again.
+    if (typeof wireGameOverCard === 'function') wireGameOverCard();
 }
 
 /**
@@ -277,6 +280,7 @@ async function connectViaRobustHybrid(sessionCode) {
                     const data = doc.data();
                     if (data.gameState) {
                         updateCenterButtonIcon(data.gameState.state);
+                        updateMobileGameOver(data.gameState);
                     }
                     if (data.feedback) {
                         handleHapticFeedback(data.feedback);
@@ -304,6 +308,7 @@ async function connectViaRobustHybrid(sessionCode) {
             
             if (sessionData.gameState) {
                 updateCenterButtonIcon(sessionData.gameState.state);
+                updateMobileGameOver(sessionData.gameState);
             }
             
         } else {
@@ -341,12 +346,14 @@ function connectViaLocalStorage(sessionCode) {
         const gameStateStr = localStorage.getItem(`session_${sessionCode}_state`);
         const gameStateData = safeParse(gameStateStr, { state: GameState.WAITING_FOR_START });
         updateCenterButtonIcon(gameStateData.state);
+        updateMobileGameOver(gameStateData);
 
         window.addEventListener('storage', function(e) {
             if (e.key === `session_${sessionCode}_state`) {
                 const data = safeParse(e.newValue, {});
                 if (data.state) {
                     updateCenterButtonIcon(data.state);
+                    updateMobileGameOver(data);
                 }
             }
         });
@@ -412,6 +419,27 @@ function updateCenterButtonIcon(currentState) {
         centerBtn.disabled = true;
         centerBtn.classList.add('playing');
         if (btnIcon) btnIcon.textContent = '🐍';
+    }
+}
+
+/**
+ * Shows/hides the phone's game-over share card and reflects the synced final score.
+ * Mirrors the desktop's score into the local gameState so share.js can read it.
+ * @param {{state:string, score:(number|undefined)}} gs - the desktop's synced game state.
+ */
+function updateMobileGameOver(gs) {
+    if (!gs) return;
+    if (typeof gs.score === 'number') gameState.score = gs.score;
+
+    const card = document.getElementById('mobile-game-over');
+    if (!card) return;
+
+    if (gs.state === GameState.GAME_OVER) {
+        const scoreEl = document.getElementById('mobile-final-score');
+        if (scoreEl) scoreEl.textContent = (typeof gs.score === 'number' ? gs.score : gameState.score).toString();
+        card.classList.remove('hidden');
+    } else {
+        card.classList.add('hidden');
     }
 }
 

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -28,9 +28,6 @@ function initializeDesktopGame() {
     const muteBtn = document.getElementById('mute-btn');
     if (muteBtn) muteBtn.addEventListener('click', toggleMute);
 
-    // Game-over share card + Play Again button (share.js).
-    if (typeof wireGameOverCard === 'function') wireGameOverCard();
-
     startGameLoop();
 }
 

--- a/public/js/share.js
+++ b/public/js/share.js
@@ -13,11 +13,9 @@ function shareUrl() {
     return `${location.origin}${location.pathname}`;
 }
 
-/** Caption for the score, with a "(new best!)" flourish when it ties/beats the best. */
+/** Caption for the score. (No high-score flair: the phone's localStorage differs from the host's.) */
 function buildShareText(score) {
-    const best = (typeof getHighScore === 'function') ? getHighScore() : 0;
-    const flair = (score > 0 && score >= best) ? ' (new best!)' : '';
-    return `I scored ${score} on Snake 🐍🔥${flair} — can you beat me?`;
+    return `I scored ${score} on Snake 🐍🔥 — can you beat me?`;
 }
 
 /** Small transient toast for share feedback (e.g. the Instagram copy fallback). */
@@ -88,9 +86,16 @@ function wireGameOverCard() {
         btn.addEventListener('click', () => openShare(btn.getAttribute('data-share')));
     });
     const playAgain = document.getElementById('play-again-btn');
-    if (playAgain && typeof restartGame === 'function') {
-        playAgain.addEventListener('click', () => restartGame());
-    }
+    if (!playAgain) return;
+    playAgain.addEventListener('click', () => {
+        // On the phone, ask the desktop host to restart; on the desktop, restart directly.
+        const onPhone = (typeof sessionManager !== 'undefined' && sessionManager && sessionManager.isDesktop === false);
+        if (onPhone && typeof sendGameAction === 'function') {
+            sendGameAction('restart');
+        } else if (typeof restartGame === 'function') {
+            restartGame();
+        }
+    });
 }
 
 // Expose for Node/Vitest only (no-op in the browser classic-script context).

--- a/public/sw.js
+++ b/public/sw.js
@@ -5,7 +5,7 @@
 // cross-origin traffic (Firebase, gstatic, unpkg, Font Awesome) is intentionally
 // left untouched so realtime sync keeps working. Bump CACHE when shell assets change.
 
-const CACHE = 'snake-shell-v3';
+const CACHE = 'snake-shell-v4';
 
 const SHELL_ASSETS = [
     './',


### PR DESCRIPTION
## 🎯 Description

Addresses feedback on the just-shipped share card:

1. **Share card → the phone.** The game-over share card (final score + WhatsApp / X / Facebook /
   Instagram + **Play Again**) now lives on the **mobile controller** as a responsive
   `#mobile-game-over` overlay — which is where sharing actually belongs (the native share sheet
   works there, the only good path for Instagram). The **desktop** game-over is now a minimal
   *Game Over + Final Score* (+ new-high badge); Space still restarts on desktop.
2. **Fixed the blank X/Twitter icon** — upgraded Font Awesome **6.0.0 → 6.7.2** (`fa-x-twitter`
   was only added in FA 6.4).
3. **Fixed the wrong "press Space" hint** on the phone card (phones have no Space key).
4. **Shrunk the oversized desktop header** (logo 80→56px, title 30→24px, creator 16→14px) + a
   small-laptop breakpoint.

**Reuse / architecture:** the phone already receives `gameState.score` + `state` via the Firestore
`onSnapshot` (`controller.js`); the desktop already writes them (`network.js`); the phone already
sends restart via `sendGameAction('restart')`. `share.js` is reused — `wireGameOverCard()`'s Play
Again is now **context-aware** (phone → `sendGameAction('restart')`, desktop → `restartGame()`), and
the score is mirrored into the phone's local `gameState` so `openShare` reads it. **No Firebase rule
changes** (score was already synced; no new doc fields).

## 🎮 Type of Change
- [x] ✨ New feature (mobile share card)
- [x] 🐛 Bug fix (blank X icon; oversized header; wrong restart hint)
- [x] 🔧 Refactor (removed desktop share styles; share logic stays in `share.js`)

## 🧪 Testing

No Node locally (see `dev-environment` memory) — `npm`/Vitest not run here; CI runs them. Verified
in-browser via `python -m http.server` + the Claude_Preview MCP, asserting on the DOM/`eval` (the SW
was cleared between checks; screenshots time out on this app).

**Desktop (1400×900):**
- Font Awesome **6.7.2** loads; header **logo 56px / title 24px**.
- Game-over is minimal: **0 share buttons**, no Play Again; restart text = "Press Space to play
  again · or use your phone".

**Mobile (375×812):**
- The `#mobile-game-over` card shows with the synced score; **all four icons render incl. X**
  (`fa-x-twitter` has a glyph, width > 0) — the FA fix is confirmed.
- Stubbing `window.open`, each share button opens the correct intent: WhatsApp `wa.me/?text=…`,
  X `twitter.com/intent/tweet?…`, Facebook `sharer.php?u=…`; Instagram falls back to opening IG
  on desktop, and uses `navigator.share` when present (real phones).
- **Play Again → `sendGameAction('restart')`** (verified `isDesktop === false` path).
- Share buttons are circular teal and scale down (48px at 375w); card is responsive.

> Note: the preview's service worker aggressively served stale JS locally, so the mobile share
> intents/Play Again were verified by loading the cache-busted `share.js`. The disk files were
> confirmed correct via grep; production is unaffected (SW cache bumped to **v4**).

**Reproduce:** desktop `python -m http.server 8000 --directory public`; open a second tab/phone with
`?session=<code>`; play → die → desktop shows minimal Game Over, phone shows the share card → tap a
share button (correct target opens) → Play Again restarts the desktop game.

## 📋 Checklist
- [x] Follows the vanilla classic-script architecture; SW cache bumped to v4
- [x] Self-reviewed the diff
- [x] Kept files small — share logic stays in `share.js`; `game.js` shrank by a line
- [x] Commented the non-obvious bits (context-aware Play Again, score mirroring, FA pitfall)
- [ ] Ran unit tests locally — **not run** (no Node; CI runs them). No tests were touched.

## 🔧 Breaking Changes
- [x] No breaking changes. The desktop game-over is intentionally simplified; share + restart move
  to the phone.

## 🚀 Deployment Notes
- [x] No special deployment needed — **hosting-only**. Touches `public/` only; **no Firebase rule
  changes**. Merging to `master` auto-deploys hosting. SW cache bump (`v3 → v4`) pulls fresh assets.
