### PR TITLE
fix(sw): serve same-origin assets network-first so code never goes stale

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,11 +1,11 @@
 // ==========================================
 // SERVICE WORKER — offline shell cache
 // ==========================================
-// Caches the static, same-origin app shell so the game loads offline. All
-// cross-origin traffic (Firebase, gstatic, unpkg, Font Awesome) is intentionally
-// left untouched so realtime sync keeps working. Bump CACHE when shell assets change.
+// Network-first for same-origin requests so the app always runs fresh code when online; the
+// cache is an OFFLINE FALLBACK only. All cross-origin traffic (Firebase, gstatic, unpkg, Font
+// Awesome) is left untouched so realtime sync keeps working. Bump CACHE when shell assets change.
 
-const CACHE = 'snake-shell-v4';
+const CACHE = 'snake-shell-v5';
 
 const SHELL_ASSETS = [
     './',
@@ -53,26 +53,19 @@ self.addEventListener('fetch', (event) => {
     // Only handle same-origin GETs; let Firebase/CDN requests go straight to network.
     if (event.request.method !== 'GET' || url.origin !== self.location.origin) return;
 
-    // Network-first for the HTML document so new deploys show up immediately.
-    if (event.request.mode === 'navigate') {
-        event.respondWith(
-            fetch(event.request).catch(() => caches.match('./index.html'))
-        );
-        return;
-    }
-
-    // Stale-while-revalidate for static assets: fast from cache, refreshed in the background.
+    // Network-first for ALL same-origin requests (HTML, JS, CSS, images): always run fresh code
+    // when online; fall back to cache only when offline. The previous strategy served the HTML
+    // network-first but assets stale-while-revalidate, so after a deploy fresh markup loaded
+    // against a STALE cached controller.js — the new UI appeared but its handlers were never
+    // wired (e.g. mobile "Play Again" did nothing) until a second reload. `cache: 'no-cache'`
+    // forces revalidation so a stale HTTP-cached copy is never used.
     event.respondWith(
-        caches.open(CACHE).then((cache) =>
-            cache.match(event.request).then((cached) => {
-                const network = fetch(event.request)
-                    .then((response) => {
-                        cache.put(event.request, response.clone());
-                        return response;
-                    })
-                    .catch(() => cached);
-                return cached || network;
+        fetch(event.request, { cache: 'no-cache' })
+            .then((response) => {
+                const copy = response.clone();
+                caches.open(CACHE).then((cache) => cache.put(event.request, copy)).catch(() => {});
+                return response;
             })
-        )
+            .catch(() => caches.match(event.request).then((cached) => cached || caches.match('./index.html')))
     );
 });


### PR DESCRIPTION
## 🎯 Description

**Fixes "Play Again from mobile doesn't work."**

**Root cause:** the service worker served `index.html` **network-first** but JS/CSS
**stale-while-revalidate**. After the last deploy, the *fresh* HTML (with the new
`#mobile-game-over` card markup) loaded against a **stale cached `controller.js`** — so the card
appeared, but `wireGameOverCard()` / `updateMobileGameOver` weren't in that stale file, leaving the
Play Again button unwired (and the card's show/hide logic missing). Same-URL, non-hashed assets +
cache-first = fresh HTML against stale code.

**Fix:** make the SW **network-first for ALL same-origin requests** (HTML, JS, CSS, images), with
the cache as an **offline fallback only**, and `cache: 'no-cache'` to force revalidation. HTML and
code now always update together, so a deploy can never leave new UI wired to old code again. Bumped
`CACHE` `v4 → v5`.

## 🎮 Type of Change
- [x] 🐛 Bug fix (mobile Play Again; and the whole "new UI shows but doesn't work after deploy" class)

## 🧪 Testing

No Node locally — verified via `python -m http.server` + Claude_Preview at a mobile viewport
(390×844). The bug reproduced exactly (stale `controller.js` → `updateMobileGameOver` undefined →
Play Again did nothing). After activating the **v5** SW:
- `controller.js` loads **fresh** (`updateMobileGameOver` is now `function`, was `undefined`).
- The mobile game-over card shows with the **synced score**.
- **Play Again calls `sendGameAction('restart')`** through the *real* init wiring (no manual
  injection) — `calls.sendGameAction: 1, lastAction: 'restart'`, `isDesktop: false`.
- No console errors.

## 🔧 Breaking Changes
- [x] No breaking changes. Behavior: the app now fetches same-origin assets from the network when
  online (revalidated) instead of cache-first; it still works offline via the cache fallback.
  Slightly more network chatter, but always-correct code — the right trade-off for a cross-device
  app that breaks when HTML and JS disagree.

## 🚀 Deployment Notes
- [x] No special deployment needed — **hosting-only**, `public/sw.js` only, no Firebase rule
  changes. After this deploys, the v5 SW installs/activates; clients get fresh, in-sync code on
  their next load (one reload may be needed to move off the old SW).
