### PR TITLE
feat(game): streak badge shows a depleting yellow timer (closes #9)

### DIFF
--- a/public/css/desktop.css
+++ b/public/css/desktop.css
@@ -504,6 +504,7 @@
     border: 1px solid rgba(255, 207, 77, 0.5);
     text-shadow: 0 0 10px rgba(255, 207, 77, 0.8);
     pointer-events: none;
+    overflow: hidden;
     z-index: 5;
     animation: comboPop var(--duration-fast) var(--ease-standard);
 }
@@ -511,6 +512,31 @@
 @keyframes comboPop {
     0% { transform: scale(0.6); opacity: 0; }
     100% { transform: scale(1); opacity: 1; }
+}
+
+/* Streak badge depletion timer (issue #9): a yellow fill that drains over the combo window.
+   The animation (duration = gameConfig.comboWindowMs) is applied inline from game.js and
+   restarted on each eat. */
+.combo-fill {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    background: linear-gradient(90deg, #ffd166, #ffb703);
+    transform-origin: left center;
+    transform: scaleX(1);
+}
+
+.combo-label {
+    position: relative;
+    z-index: 1;
+    color: #ffffff;
+    /* Readable over BOTH the yellow fill and the drained-dark area. */
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.95);
+}
+
+@keyframes comboDeplete {
+    from { transform: scaleX(1); }
+    to   { transform: scaleX(0); }
 }
 
 /* Shrink the header on smaller laptops so it stays proportionate. */

--- a/public/index.html
+++ b/public/index.html
@@ -112,7 +112,10 @@
             <div class="game-area">
                 <div class="game-board-container">
                     <canvas id="game-canvas" width="600" height="600"></canvas>
-                    <div id="combo-display" class="combo-display hidden"></div>
+                    <div id="combo-display" class="combo-display hidden">
+                        <span class="combo-fill"></span>
+                        <span class="combo-label"></span>
+                    </div>
                     <div id="game-over" class="game-over hidden">
                         <div class="game-over-content">
                             <h2>Game Over!</h2>

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -542,11 +542,25 @@ function updateComboDisplay() {
     if (!el) return;
     const multiplier = Math.min(gameState.combo, gameConfig.maxCombo);
     if (multiplier > 1) {
-        el.textContent = `🔥 x${multiplier}`;
+        const label = el.querySelector('.combo-label');
+        if (label) label.textContent = `🔥 x${multiplier}`;
         el.classList.remove('hidden');
+        restartComboTimer(); // (re)fill the yellow timer; it drains over comboWindowMs
     } else {
         el.classList.add('hidden');
     }
+}
+
+/**
+ * Restart the streak badge's draining yellow fill from full. Called on each streak-eat; the
+ * fill empties over gameConfig.comboWindowMs, matching the combo-expiry window (issue #9).
+ */
+function restartComboTimer() {
+    const fill = document.querySelector('#combo-display .combo-fill');
+    if (!fill) return;
+    fill.style.animation = 'none';
+    void fill.offsetWidth; // force reflow so the animation restarts from full
+    fill.style.animation = `comboDeplete ${gameConfig.comboWindowMs}ms linear forwards`;
 }
 
 /**


### PR DESCRIPTION
## 🎯 Description

**Closes #9.** The combo/streak badge (🔥 ×N, top-right of the board) now shows **how long the
streak has left**: it fills with **yellow that drains horizontally** over the streak window
(`gameConfig.comboWindowMs`, 4.5s) and **refills on each eat**, so the player can see at a glance how
long they have to grab the next food before the streak resets.

## How it works
- The badge is split into a `.combo-fill` (gold gradient that drains via `transform: scaleX`) and a
  `.combo-label` (white text with a dark shadow so it stays readable over both the yellow fill and
  the drained-dark area — the old gold text would vanish on the gold fill).
- A CSS `@keyframes comboDeplete` animates `scaleX 1 → 0`. The **duration is set to
  `gameConfig.comboWindowMs` inline from `game.js`** and **restarted on each eat** via a small
  `restartComboTimer()` helper (`updateComboDisplay()` already runs on every eat). It's time-based,
  so it's **frame-rate independent** and stays aligned with the existing combo-expiry check.
- **No change** to the combo build / expiry / reset logic — purely additive. Desktop-only (the combo
  runs on the game host).

## 🎮 Type of Change
- [x] ✨ New feature (streak countdown visualization)

## 🧪 Testing

No Node locally — verified via `python -m http.server` + Claude_Preview (desktop viewport). The
preview tab is `hidden`, which pauses CSS animations, so I drove the animation's `currentTime` via
the Web Animations API:
- `0ms → scaleX 1` (full), `2250ms → scaleX 0.5` (half), `4500ms → scaleX 0` (empty) — a clean
  linear horizontal drain over `comboWindowMs`.
- One animation (no dupes); duration 4500ms; gold gradient fill (`#ffd166…`); `.combo-label` computed
  color is white.
- `updateComboDisplay()` with `combo=3` shows "🔥 x3"; a simulated eat updates to "🔥 x4" and
  restarts the fill; `combo=0` hides the badge.
- No console errors.

**Reproduce:** desktop `python -m http.server 8000 --directory public`; play with arrows/WASD; eat
two foods quickly → the 🔥 badge appears with a draining yellow fill; eat again before it empties →
it refills; dawdle → it empties and the badge clears.

## 🔧 Breaking Changes
- [x] None. Additive to the existing badge.

## 🚀 Deployment Notes
- [x] Hosting-only; `public/` only; no Firebase rule changes. **No service-worker cache bump** needed
  — the SW is network-first now (PR #8), so clients pick up the new CSS/JS on their next online load.
