### PR TITLE
docs: refresh README, CLAUDE.md, CONTRIBUTING & architecture

### DIFF
--- a/.agent/system/architecture.md
+++ b/.agent/system/architecture.md
@@ -1,21 +1,54 @@
 # Architecture
 
 ## Overview
-This is a web-based Snake game using vanilla JavaScript and CSS, deployed via Firebase Hosting.
+A cross-device Snake game: the **desktop** browser hosts and renders the game; a **phone** acts as a
+wireless analog joystick. They pair over a 6-digit session code / QR code. Built with vanilla JS and
+deployed via Firebase Hosting. Live: https://go-console-84748.web.app/
 
-## Tech Stack
-- Frontend: HTML5, CSS3, ES6+ JavaScript
-- Backend/Infra: Firebase Hosting
+## Tech stack
+- **Frontend:** HTML5 Canvas + CSS3 + ES6+ JavaScript — **no bundler, no ES modules**.
+- **Realtime backend:** Firebase (v8 compat SDK) — **Firestore** for session metadata / game state /
+  actions, **Realtime Database** for the high-frequency joystick stream. `localStorage` fallback for
+  single-device use.
+- **Delivery:** PWA (installable, network-first service worker) on Firebase Hosting.
 
-## Directory Structure
-- `public/`: The deployable static assets.
-  - `public/css/`: Split CSS files (e.g., `desktop.css`, `mobile.css`, `style.css` which may import or represent older concatenated code).
-  - `public/js/`: Modular JS (e.g., `controller.js`, `game.js`, `main.js`). Note that older iterations might strictly use `app.js`.
-  - `public/index.html`: The entry point for the browser.
-- `.firebase/`, `firebase.json`, `.firebaserc`: Standard Firebase project config.
-- `.github/workflows/`: Contains automated deployment logic for Firebase upon pushing to `main`.
+## Two roles, one page
+`public/index.html` contains both `#desktop-view` and `#mobile-view`. The view is chosen at load by
+viewport width (`<= 768px`) or the presence of a `?session=` URL param. The **desktop** owns the game
+loop, movement, collision, rendering, and the combo lifecycle; the **phone** captures the joystick and
+sends start/restart actions.
 
-## Design Principles
-1. **Separation of Concerns**: UI, Game Logic, and Input are meant to be separated into logical files (e.g. `css/*` and `js/*`).
-2. **Event Driven**: Using native event listeners for keyboard movement (`controller.js`).
-3. **Responsive**: We use media queries or specific stylesheets for desktop vs. mobile layouts.
+## Load order (no import graph)
+Plain `<script>`s share **one global scope**, loaded in this fixed order — earlier files define globals
+later files consume:
+
+```
+utils.js → logic.js → config.js → state.js → leaderboard.js → sound.js → effects.js →
+network.js → game.js → share.js → controller.js → main.js
+```
+
+CSS load order: `variables.css` (tokens) → `base.css` → `desktop.css` / `mobile.css`.
+
+## Directory structure
+- `public/` — the deployable static app (Firebase Hosting serves only this).
+  - `public/js/` — the 12 scripts above. Pure, testable math lives in `logic.js` (covered by `tests/`).
+  - `public/css/` — split, token-driven styles (no `style.css`; no concatenated monolith).
+  - `public/index.html` — entry point holding both views.
+  - `public/sw.js` + `public/manifest.json` — PWA service worker (network-first) + manifest.
+- `tests/` — Vitest unit tests for `logic.js`.
+- `firebase.json`, `.firebaserc`, `database.rules.json` — Firebase project config (rules are **not**
+  shipped by CI).
+- `.github/workflows/deploy.yml` — GitHub Actions: lint + test (non-blocking) → `firebase deploy
+  --only hosting` on push to **`master`**.
+
+## Data flow
+Phone writes joystick input (RTDB) + start/restart (Firestore); desktop listens and runs physics.
+Direction is **continuous (radians), not 4-way**, and speed scales with joystick magnitude. Eating
+within `gameConfig.comboWindowMs` builds a combo multiplier (capped at `maxCombo`).
+
+## Design principles
+1. **Separation of concerns** — input (`controller.js`), sync (`network.js`), simulation (`game.js`),
+   pure math (`logic.js`), and presentation (`css/*`) stay in distinct files.
+2. **Testable core** — gameplay math is pure and unit-tested; the rest is thin glue around it.
+3. **Resilient sync** — Firestore + RTDB with a `localStorage` fallback so it works on one device.
+4. **Responsive by role** — desktop vs. mobile layouts via dedicated stylesheets + viewport detection.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,14 +10,18 @@ https://go-console-84748.web.app/
 
 ## Commands
 
-- `npm install` — install dev deps (only `firebase-tools`).
+- `npm install` — install dev tooling (`firebase-tools`, `eslint`, `vitest`, `prettier`).
 - `npm start` — serve `public/` locally (`npx serve -s public`). Open the printed URL; append
   `?session=123456` to force the mobile/controller view in a second tab/device.
+- `npm run lint` (ESLint) · `npm test` (Vitest — pure-logic unit tests in `tests/`) ·
+  `npm run format` (Prettier).
 - **Deploy is automatic** on push to `master` via GitHub Actions
-  (`.github/workflows/deploy.yml`), which runs `firebase deploy --only hosting`. Do **not** run
-  `firebase deploy` by hand (`.agent/workflows/deploy.md`). Note the Action deploys *hosting
-  only* — changes to `database.rules.json` or Firestore rules are **not** shipped by CI.
-- No lint or test setup yet.
+  (`.github/workflows/deploy.yml`, "Fast Deploy - CI/CD"), which runs `firebase deploy --only
+  hosting`. Do **not** run `firebase deploy` by hand (`.agent/workflows/deploy.md`). Note the
+  Action deploys *hosting only* — changes to `database.rules.json` or Firestore rules are **not**
+  shipped by CI.
+- CI runs `lint` + `test`, but both are **non-blocking** (`continue-on-error`) until verified green;
+  the build is gated only on `node --check` syntax + a couple of grep sanity checks.
 
 ## Architecture (the non-obvious parts)
 
@@ -25,7 +29,8 @@ https://go-console-84748.web.app/
 order, all sharing one global scope:
 
 ```
-config.js → state.js → network.js → game.js → controller.js → main.js
+utils.js → logic.js → config.js → state.js → leaderboard.js → sound.js → effects.js →
+network.js → game.js → share.js → controller.js → main.js
 ```
 
 Functions and the large mutable state objects (`gameState`, `sessionManager`, `joystickState`,
@@ -49,16 +54,27 @@ SDK (`firebase.firestore()`, `firebase.database()`), *not* v9 modular:
 **Data flow.** Desktop owns the game loop, physics, and collision (`game.js`) and listens for
 joystick input (RTDB) + actions (Firestore). Mobile captures the joystick and writes input
 (RTDB) + start/restart (Firestore). Direction is **continuous (radians), not 4-way**; speed
-scales with joystick magnitude.
+scales with joystick magnitude. Eating again within `gameConfig.comboWindowMs` builds a combo
+multiplier (capped at `maxCombo`), surfaced as a draining yellow badge over the board.
 
 ### File roles (`public/`)
+- `js/utils.js` — small shared helpers.
+- `js/logic.js` — **pure, testable** game math: joystick→angle/speed mapping, collision, turn step.
+  Unit-tested in `tests/` (the only code with real coverage).
 - `js/config.js` — Firebase init + all tunables (`gameConfig`) + `colors` + `GameState` enum.
 - `js/state.js` — the global mutable state objects.
+- `js/leaderboard.js` — **local** high-score tracking via `localStorage`. **Not** a global/Firestore
+  leaderboard (despite the name — that was scoped but never built).
+- `js/sound.js` — synthesized Web Audio SFX (food/crash/start) + mute toggle; food pitch rises with the combo.
+- `js/effects.js` — juice: particle bursts, ripples, score pops, screen shake (desktop render).
 - `js/network.js` — desktop session lifecycle, Firestore/RTDB wiring, QR generation, localStorage fallback.
-- `js/game.js` — canvas rendering, movement, and collision (desktop only).
-- `js/controller.js` — mobile joystick capture and connection.
+- `js/game.js` — desktop game loop: canvas rendering, movement, collision, and the combo lifecycle.
+- `js/share.js` — the phone game-over card + social share intents (WhatsApp / X / Facebook / Instagram).
+- `js/controller.js` — mobile joystick capture, connection, and game-over-card wiring.
 - `js/main.js` — entry point / device detection.
 - `css/` — load order `variables.css` (tokens) → `base.css` → `desktop.css` / `mobile.css`.
+- `sw.js` + `manifest.json` — PWA: installable + offline shell. The SW is **network-first** for
+  same-origin requests (cache = offline fallback only); bump `CACHE` when shell assets change.
 
 ## Conventions
 
@@ -78,3 +94,7 @@ scales with joystick magnitude.
   not fully captured in version control.
 - Everything shares global scope — renaming a function or variable can silently break a consumer
   in another file.
+- The PWA **service worker is network-first**, so online users always get fresh code — but an
+  already-installed SW still needs one reload to update after a deploy. When you change shell
+  assets, bump `const CACHE` in `sw.js`. (Local preview can serve stale assets; see
+  `.claude` memory / unregister the SW + clear caches when verifying.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,21 +26,20 @@ Thank you for your interest in contributing! We welcome contributions from devel
    firebase init hosting
    ```
 
-3. **Start local development server**
+3. **Start a local server** (no build step — just serve `public/`)
    ```bash
-   # Using Python
-   python -m http.server 8000
-   
-   # Using Node.js
-   npx http-server
-   
-   # Using PHP
-   php -S localhost:8000
+   # Project script (Node)
+   npm install && npm start                      # → npx serve -s public (http://localhost:3000)
+
+   # …or any static server, pointed at public/
+   python -m http.server 8000 --directory public
+   npx http-server public
    ```
 
-4. **Test the application**
-   - Desktop: `http://localhost:8000?mode=desktop`
-   - Mobile: `http://localhost:8000?mode=mobile`
+4. **Open the app**
+   - **Desktop (host):** open the served URL (e.g. `http://localhost:3000`) in a normal-width window.
+   - **Mobile (controller):** append `?session=123456` to that URL, or open it on a phone. The view
+     is chosen by viewport width (`<= 768px`) or the `?session=` param — there is **no** `?mode=` flag.
 
 ## 🎯 How to Contribute
 
@@ -83,11 +82,11 @@ Thank you for your interest in contributing! We welcome contributions from devel
    - Test on different screen sizes
    - Verify joystick functionality
 
-4. **Commit with clear messages**
+4. **Commit with [Conventional Commits](https://www.conventionalcommits.org/)** (`feat | fix | refactor | style`)
    ```bash
-   git commit -m "Add: New joystick sensitivity setting"
-   git commit -m "Fix: Mobile connection timeout issue"
-   git commit -m "Update: README installation instructions"
+   git commit -m "feat(controller): add joystick sensitivity setting"
+   git commit -m "fix(network): handle mobile connection timeout"
+   git commit -m "docs: update local-dev instructions"
    ```
 
 5. **Push and create PR**
@@ -124,19 +123,19 @@ function handleJoystickInput(input) {
 
 ### CSS
 ```css
-/* Use BEM methodology for CSS classes */
-.joystick__base {
+/* Class names are kebab-case (not BEM); keep them descriptive. */
+.joystick-base {
     position: relative;
 }
 
-.joystick__handle--dragging {
+.joystick-handle.dragging {
     transform: scale(1.1);
 }
 
-/* Use CSS custom properties for themes */
-:root {
-    --primary-color: #ff1493;
-    --background-color: #0a0a0a;
+/* Reuse the design tokens in css/variables.css — the palette is teal/gold, not pink. */
+.score-value {
+    color: var(--color-primary);          /* teal */
+    background: var(--color-background);   /* near-black */
 }
 ```
 
@@ -179,23 +178,27 @@ function handleJoystickInput(input) {
 ## 🏗️ Project Structure
 
 ```
-├── public/
-│   ├── css/           # Modular CSS files
-│   ├── js/            # Modular Javascript logic
-│   ├── index.html     # Main HTML structure
-│   └── ...            # Assets and other scripts
-├── firebase.json       # Firebase hosting configuration
-├── .github/
-│   ├── workflows/      # GitHub Actions CI/CD
-│   └── ISSUE_TEMPLATE/ # Issue templates
-└── README.md           # Project documentation
+├── public/                 # Everything that ships (Firebase Hosting serves this)
+│   ├── css/                # variables → base → desktop / mobile (load order matters)
+│   ├── js/                 # 12 plain <script>s, one shared global scope, no bundler
+│   ├── index.html          # both views: desktop host + mobile controller
+│   ├── sw.js               # network-first service worker (PWA offline shell)
+│   └── manifest.json       # PWA manifest
+├── tests/                  # Vitest unit tests for js/logic.js
+├── firebase.json           # Firebase Hosting config
+├── .github/workflows/      # GitHub Actions CI/CD (auto-deploy on master)
+├── CLAUDE.md               # architecture map for contributors & AI agents
+└── .agent/                 # deeper semantic index (SOPs, workflows, architecture)
 ```
 
 ### Key Components
-- **Game Engine**: Canvas-based rendering in `app.js`
-- **Session Management**: Firebase/localStorage hybrid system
-- **Mobile Controller**: Touch-based joystick interface
-- **Connection System**: QR code + manual code entry
+- **Game engine** — canvas rendering, movement, collision, and combo logic in `js/game.js`
+  (pure math factored into `js/logic.js`, which is unit-tested in `tests/`).
+- **Session sync** — Firestore (state/actions) + Realtime Database (joystick), with a
+  `localStorage` fallback, in `js/network.js` / `js/controller.js`.
+- **Mobile controller** — touch joystick + center ▶ button in `js/controller.js`.
+- **Connection** — QR code + 6-digit code; scanning auto-connects via a `?session=` URL param.
+- **Feel** — `js/sound.js` (Web Audio SFX), `js/effects.js` (particles/shake), `js/share.js` (score card).
 
 ## 🐛 Common Issues & Solutions
 

--- a/README.md
+++ b/README.md
@@ -1,62 +1,101 @@
-# 🐍 Cross-Device Snake Game
+<div align="center">
 
-A modern take on the classic Snake game where you play on your desktop and use your smartphone as a wireless controller!
+# 🐍 Cross-Device Snake
 
-[![Play Demo](https://img.shields.io/badge/🎮-Play_Live_Demo-FF4B4B?style=for-the-badge&logoColor=white)](https://go-console-84748.web.app/)
-[![Firebase](https://img.shields.io/badge/Firebase-Firestore-orange?style=flat-square)](https://console.firebase.google.com/)
+**Play on your desktop. Steer with your phone.**
+Scan a QR code and your phone becomes a wireless, analog joystick.
+
+[![Play the live demo](https://img.shields.io/badge/▶_Play-Live_Demo-19c3b2?style=for-the-badge)](https://go-console-84748.web.app/)
+
+[![PWA](https://img.shields.io/badge/PWA-installable-22d3c5?style=flat-square)](https://go-console-84748.web.app/)
+[![Vanilla JS](https://img.shields.io/badge/Vanilla_JS-no_bundler-f7df1e?style=flat-square)](#-tech)
+[![Firebase](https://img.shields.io/badge/Firebase-Firestore_+_RTDB-ffa000?style=flat-square)](https://firebase.google.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
 
----
-
-## 🎮 How to Play
-
-### 1. Host on Desktop
-Open the [Live Demo](https://go-console-84748.web.app/) on your computer. A unique **6-digit session code** and QR code will appear.
-
-### 2. Connect Mobile
-Scan the QR code with your phone or enter the session code manually.
-
-### 3. Control
-- **Joystick**: Rotate to turn, pull further for a **speed boost**.
-- **Play Button (▶)**: Start the game.
-- **Restart Button (↻)**: Play again after a crash.
+</div>
 
 ---
 
-## 🚀 Local Development
+## 🎮 How to play
 
-If you want to run the project locally or contribute:
+1. **Host** — open the [demo](https://go-console-84748.web.app/) on a computer. A glowing QR code + 6-digit code appears.
+2. **Connect** — scan the QR with your phone camera (or type the code). It **auto-connects** — no app, no install.
+3. **Play** — tap **▶** to start, then tilt the joystick to steer. Push further to go faster.
 
-### Prerequisites
-- Node.js (v16+)
-- [Firebase account](https://console.firebase.google.com/) (optional, for cross-device features)
-
-### Setup
-1. **Clone & Install**
-   ```bash
-   git clone https://github.com/yourusername/snake-game.git
-   cd snake-game
-   npm install
-   ```
-
-2. **Configuration**
-   Add your Firebase credentials to `public/js/config.js`.
-
-3. **Run**
-   ```bash
-   npm start
-   # Visit http://localhost:3000
-   ```
+> The snake **never stops** — you steer it at any angle (not just up/down/left/right), and speed scales with how far you push the stick. Eat food quickly to build a 🔥 **combo** (up to ×6) before the streak timer drains.
 
 ---
 
-## 🔥 Key Features
-- **Zero Latency**: Real-time sync via Firebase Firestore.
-- **Cross-Platform**: Works on any modern browser (iOS, Android, Windows, macOS).
-- **Smart Fallback**: Automatic `localStorage` mode for testing on a single device.
-- **Responsive Design**: Custom-built touch joystick for mobile controllers.
+## ✨ Features
+
+- 📱 **Phone-as-controller** — a custom touch joystick streamed to the desktop in near real-time over Firebase.
+- 🎯 **Analog, continuous-angle movement** — steer by angle; magnitude controls speed. No grid-snapping.
+- 🔥 **Combo streaks** — chain quick eats for a score multiplier, shown as a draining yellow timer badge.
+- 🎆 **Juice** — particle bursts, ripples, floating score pops, and screen shake on impact.
+- 🔊 **Synthesized sound** — Web Audio SFX whose pitch climbs with your combo; one-tap mute.
+- 🤳 **Flex your score** — share to WhatsApp, X, Facebook, or Instagram straight from your phone.
+- ⚡ **Offline-ready PWA** — installable, with a network-first service worker.
+- 🛟 **Single-device fallback** — a `localStorage` mode kicks in automatically when Firebase isn't available.
 
 ---
 
-**Made with ❤️ for the retro gaming community.**  
-*Feel free to ⭐ star this repo if you enjoyed the game!*
+## 🕹️ Controls
+
+| Control | Action |
+| --- | --- |
+| 🕹️ **Joystick** | Rotate to steer (any angle) · push further to speed up |
+| ▶ **Center button** | Start the game (turns into 🐍 while playing) |
+| ⌨️ **Space / Enter** *(desktop)* | Restart after a crash |
+| 🔁 **Play Again** *(phone)* | Restart from the game-over share card |
+
+---
+
+## 🛠️ Tech
+
+Vanilla **JavaScript** (no bundler, no modules) · HTML5 **Canvas** · **Firebase** Firestore *(session + game state)* + Realtime Database *(joystick stream)* · **PWA** *(installable, offline shell)* · **Firebase Hosting** with auto-deploy via GitHub Actions.
+
+---
+
+## 💻 Local development
+
+There's **no build step** — just serve the static `public/` folder.
+
+```bash
+npm install      # dev tooling only: firebase-tools, eslint, vitest, prettier
+npm start        # → npx serve -s public   (http://localhost:3000)
+```
+
+Any static server works too, e.g. `python -m http.server 8000 --directory public`.
+
+- Open on a **desktop-width** window to host the game.
+- Append **`?session=123456`** to the URL (or open on a phone) to load the **controller** view in a second tab/device.
+
+```bash
+npm run lint     # ESLint
+npm test         # Vitest unit tests (tests/)
+npm run format   # Prettier
+```
+
+**Deploys are automatic** on push to `master` (GitHub Actions → `firebase deploy --only hosting`). Database/Firestore rules are **not** shipped by CI.
+
+---
+
+## 📐 Architecture
+
+Plain `<script>` files share **one global scope**, loaded in a fixed order — there's no import graph. The **desktop** owns the game loop, rendering, and collision; the **phone** captures the joystick. They pair over a 6-digit code / QR via Firebase, with a `localStorage` fallback for single-device use.
+
+> 🤖 Full map for contributors and AI agents lives in **[CLAUDE.md](CLAUDE.md)**, with a deeper index under **[`.agent/`](.agent/)**.
+
+---
+
+## 🤝 Contributing
+
+PRs welcome — see **[CONTRIBUTING.md](CONTRIBUTING.md)**. We use [Conventional Commits](https://www.conventionalcommits.org/) (`feat | fix | refactor | style`) and branch as `feature/…`, `bugfix/…`, `docs/…`.
+
+---
+
+<div align="center">
+
+Made with ❤️ by **[Aryaman Godara](https://www.linkedin.com/in/aryamangodara/)** · ⭐ the repo if you enjoyed it!
+
+</div>


### PR DESCRIPTION
Documentation-only refresh — the docs had drifted from the code. No behavior changes.

## README.md
Concise, aesthetic rewrite that documents the **real** feature set: analog/continuous-angle movement, 🔥 combo streaks with the draining timer, juice (particles/shake), Web Audio SFX, the phone share card, the new QR **"Scan to Play"** onboarding, and the PWA. Fixes:
- ❌ Removed the **"Restart Button (↻)"** — it never existed (restart is Space/Enter on desktop, "Play Again" on the phone card).
- Corrected run/dev steps (`npm start` → `npx serve -s public`, the `?session=` controller view).
- Dropped marketing fluff ("Zero Latency") for honest "near real-time".

## CLAUDE.md
- Corrected the **`<script>` load order** (was 6 files, actually 12: `utils → logic → config → state → leaderboard → sound → effects → network → game → share → controller → main`).
- Added file roles for `utils/logic/leaderboard/sound/effects/share` + `sw.js`.
- Replaced **"No lint or test setup yet"** with the real ESLint/Vitest/Prettier + **non-blocking CI** status.
- Added combo and **network-first service-worker** notes.

## CONTRIBUTING.md
- `app.js` → `js/game.js`; `?mode=desktop/mobile` → `?session=` / width-based; pink `#ff1493` → teal tokens + kebab-case classes (not BEM); `Add:/Fix:/Update:` → **Conventional Commits**; refreshed the project map.

## .agent/system/architecture.md
- Rewrote to the real stack, load order, and data flow (dropped `app.js` / `style.css` / deploy-on-`main`).

### Accuracy guardrails
Verified against the code first — explicitly did **not** document the **global leaderboard** (it's `localStorage`-only) or **skins/themes** (never built), since neither exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)