### PR TITLE
feat(analytics): Firebase Analytics (GA4) with cross-device event tracking

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,7 @@
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-database.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-firestore.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-analytics.js"></script>
     
     <!-- QR Code generation -->
     <script src="https://unpkg.com/qrious@4.0.2/dist/qrious.min.js"></script>
@@ -287,6 +288,14 @@
                     .catch(function(err) { console.warn('Service worker registration failed:', err); });
             });
         }
+
+        // PWA install funnel → GA4 (trackEvent is a no-op when analytics is unavailable).
+        window.addEventListener('beforeinstallprompt', function() {
+            if (typeof trackEvent === 'function') trackEvent('pwa_install', { outcome: 'prompted' });
+        });
+        window.addEventListener('appinstalled', function() {
+            if (typeof trackEvent === 'function') trackEvent('pwa_install', { outcome: 'installed' });
+        });
     </script>
 </body>
 </html>

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -16,7 +16,7 @@ const firebaseConfig = {
 };
 
 // Initialize Firebase with HYBRID approach: Realtime Database + Firestore
-let app, database, firestore;
+let app, database, firestore, analytics;
 let firebaseReady = false;
 
 /**
@@ -37,6 +37,13 @@ function initializeFirebase() {
         // Firestore only for session management (Less frequent updates)
         firestore = firebase.firestore();
         firebaseReady = true;
+        // Analytics (GA4). Its own try/catch so an analytics failure (adblock, unsupported
+        // env) never falls into the outer catch and drops gameplay into offline mode.
+        try {
+            analytics = firebase.analytics();
+        } catch (e) {
+            console.warn('Analytics unavailable:', e);
+        }
         console.log('🚀 Firebase initialized: Realtime DB + Firestore hybrid');
     } catch (error) {
         console.warn('Firebase initialization failed:', error);

--- a/public/js/controller.js
+++ b/public/js/controller.js
@@ -11,6 +11,9 @@ function initializeMobileController() {
     // Check if session code is passed in URL query param
     const urlParams = new URLSearchParams(window.location.search);
     const sessionFromUrl = urlParams.get('session');
+
+    // Attribute how the controller arrived: scanning the QR carries ?session=, manual entry doesn't.
+    trackEvent('controller_arrival', { method: sessionFromUrl ? 'qr' : 'manual_code' });
     
     if (sessionFromUrl) {
         const sessionInput = document.getElementById('session-input');
@@ -273,6 +276,7 @@ async function connectViaRobustHybrid(sessionCode) {
             showControllerInterface();
             showConnectionSuccess();
             console.log('✅ Successfully connected to hybrid session:', sessionCode);
+            trackEvent('controller_connected', { side: 'phone' });
             
             // Listen to Firestore for session server updates
             sessionManager.firestoreUnsubscribe = sessionDoc.onSnapshot((doc) => {

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -128,6 +128,7 @@ function startGameLoop() {
 function startGame() {
     console.log('🚀 Starting game with continuous snake movement!');
     gameState.currentState = GameState.PLAYING;
+    trackEvent('game_start', {});
     playStartSound();
     gameState.direction = 0; // Start facing right
     gameState.targetDirection = 0;
@@ -154,6 +155,7 @@ function startGame() {
  */
 function restartGame() {
     console.log('🔄 Restarting game with continuous movement!');
+    trackEvent('game_restart', {});
     
     gameState = {
         snake: createInitialSnake(),
@@ -591,6 +593,11 @@ function gameOver() {
     updateHighScoreDisplay();
     const newHighEl = document.getElementById('new-high-score');
     if (newHighEl) newHighEl.classList.toggle('hidden', !isNewBest);
+
+    // Analytics: the run's score + whether it set a new personal best. post_score is a
+    // GA4-recommended event that surfaces in the Games engagement reports.
+    trackEvent('game_over', { score: gameState.score, is_high_score: isNewBest });
+    trackEvent('post_score', { score: gameState.score });
 
     // Hitstop: let the impact register for a beat before the modal slides in. The
     // snake is already frozen (state = GAME_OVER), so the canvas just keeps shaking.

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -8,6 +8,15 @@
 function detectDevice() {
     const isMobile = window.innerWidth <= 768;
     sessionManager.isDesktop = !isMobile;
+
+    // Tag the GA4 session with the device role so the two audiences are segmentable.
+    try {
+        if (typeof analytics !== 'undefined' && analytics) {
+            analytics.setUserProperties({
+                device_role: sessionManager.isDesktop ? 'desktop_host' : 'phone_controller'
+            });
+        }
+    } catch (e) { /* ignore */ }
     
     console.log('Device detected:', sessionManager.isDesktop ? 'Desktop' : 'Mobile');
     

--- a/public/js/network.js
+++ b/public/js/network.js
@@ -24,6 +24,8 @@ async function generateNewSession() {
     } else {
         setupLocalStorageSession(sessionCode);
     }
+
+    trackEvent('session_created', { connection: firebaseReady ? 'hybrid' : 'localStorage' });
 }
 
 /**
@@ -117,6 +119,11 @@ async function setupRobustHybridSession(sessionCode) {
             if (controllerData && controllerData.connected) {
                 handleJoystickInputFromMobile(controllerData.joystick || { x: 0, y: 0 });
                 updateConnectionStatus('Mobile controller connected ✅');
+                // Fire once per session — this listener re-runs on every joystick update.
+                if (!sessionManager.controllerTracked) {
+                    sessionManager.controllerTracked = true;
+                    trackEvent('controller_connected', { side: 'desktop' });
+                }
             }
         });
         

--- a/public/js/share.js
+++ b/public/js/share.js
@@ -58,6 +58,7 @@ function shareToInstagram(text, url) {
 /** Route a share button to its network's web intent. */
 function openShare(network) {
     const score = (typeof gameState !== 'undefined' && gameState) ? gameState.score : 0;
+    trackEvent('share', { method: network, content_type: 'score' });
     const text = buildShareText(score);
     const url = shareUrl();
     const t = encodeURIComponent(text);

--- a/public/js/sound.js
+++ b/public/js/sound.js
@@ -67,6 +67,7 @@ function playStartSound() {
  */
 function toggleMute() {
     soundMuted = !soundMuted;
+    trackEvent('mute_toggle', { muted: soundMuted });
     try {
         localStorage.setItem('snake_muted', JSON.stringify(soundMuted));
     } catch (error) {

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -20,3 +20,23 @@ function safeParse(str, fallback = {}) {
         return fallback;
     }
 }
+
+/**
+ * Fire a Google Analytics (GA4) event. Hardened so analytics can NEVER break gameplay: it
+ * no-ops when the analytics handle is absent (Firebase init failed, offline/localStorage
+ * fallback, or an ad-blocker) and swallows any error. Every event is auto-tagged with the
+ * device role so desktop hosts and phone controllers stay segmentable. Never pass PII or the
+ * 6-digit session code — keep params low-cardinality (numbers / bounded enums).
+ * @param {string} name - GA4 event name.
+ * @param {object} [params={}] - Event parameters.
+ */
+function trackEvent(name, params = {}) {
+    try {
+        if (typeof analytics === 'undefined' || !analytics) return;
+        const role = (typeof sessionManager !== 'undefined' && sessionManager
+            && sessionManager.isDesktop === false) ? 'phone_controller' : 'desktop_host';
+        analytics.logEvent(name, { device_role: role, ...params });
+    } catch (error) {
+        /* analytics must never throw into gameplay */
+    }
+}


### PR DESCRIPTION
Adds **Firebase Analytics (GA4)** so the audience can be analyzed and marketing campaigns attributed. Turns on the GA4 property already provisioned for this Firebase project (`measurementId: G-0DFSB38H21`) — **no Firebase/GA console setup needed**. Per owner choice: **no consent banner** (GA4 anonymizes IPs by default).

## What you get
- **Audience** (automatic): country, device, browser, language, new vs returning.
- **Acquisition / campaigns** (automatic): referrer + `utm_source/medium/campaign` from the landing URL — just tag your ad/QR/social links (e.g. `?utm_source=instagram&utm_campaign=launch`).
- **Custom funnel events**, every one tagged **`desktop_host` vs `phone_controller`**:
  `session_created` · `controller_arrival` (`qr` vs `manual_code`) · `controller_connected` · `game_start` · `game_restart` · `game_over` (+ `score`, `is_high_score`) · `post_score` · `share` (by platform) · `mute_toggle` · `pwa_install`.

## How it's wired (safe by design)
- `firebase-analytics.js` 8.10.1 added in `<head>`; a guarded `analytics` handle in `config.js` (its **own** try/catch so an analytics failure never drops the app into offline mode).
- One hardened **`trackEvent()`** helper in `utils.js`: no-ops under ad-block / offline, wraps everything in try/catch (**analytics can never break gameplay**), and auto-attaches `device_role`. Device role is also set as a GA4 user property in `main.js`.
- The desktop `controller_connected` is **once-guarded** (the RTDB listener re-fires on every joystick update). No PII / no 6-digit session code is ever logged.
- **No changes** to `sw.js` (it already lets cross-origin Google requests pass through), CSS, or `firebaseConfig`.

## Verification (Python http.server + Claude_Preview; eval + network)
- `gtag/js?id=G-0DFSB38H21` loads; `analytics` handle created; `trackEvent` present; `firebaseReady: true`.
- Real GA4 `/g/collect` requests fire with correct params:
  - `en=controller_arrival … ep.device_role=phone_controller … ep.method=manual_code … up.device_role=phone_controller`
  - `en=desktop_role_check … ep.device_role=desktop_host … epn.ok=1`
  - `game_over`/`post_score` also send (batched into the POST body).
- **Zero console errors**; `gameOver()` runs cleanly — gameplay unaffected. (Ad-blockers can block `/collect`; that's not a wiring failure.)

## After merge (owner, optional, in GA4 Admin)
- Exclude dev/localhost traffic (internal-traffic filter or a separate Dev stream) so test hits don't pollute the data.
- Use **DebugView** for live event checks; standard reports lag a few hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)