### PR TITLE
docs: document GA4 analytics + how to view it

### DIFF
--- a/.agent/system/analytics.md
+++ b/.agent/system/analytics.md
@@ -1,0 +1,83 @@
+# Analytics (Google Analytics 4)
+
+The game uses **Firebase Analytics (GA4)** to understand the audience and attribute marketing
+campaigns. GA4 property/measurement ID: **`G-0DFSB38H21`** (already in `firebaseConfig`,
+`public/js/config.js`). No cookie-consent banner is shown (owner choice; GA4 anonymizes IPs by
+default).
+
+## How it's wired
+
+- `public/index.html` `<head>` loads `firebase-analytics.js` (v8 compat, **8.10.1** — must match the
+  other Firebase tags).
+- `public/js/config.js` creates a **guarded** `analytics` handle in its own `try/catch`, so an
+  analytics failure (ad-block, unsupported env) never falls into the DB-init catch and drops the app
+  into offline mode.
+- `public/js/utils.js` exposes the single entry point:
+
+  ```js
+  trackEvent(name, params)   // no-ops if analytics is absent; never throws into gameplay;
+                             // auto-tags device_role = 'desktop_host' | 'phone_controller'
+  ```
+
+- `public/js/main.js` also sets `device_role` as a GA4 **user property** (segments sessions by role).
+
+**Guardrails:** analytics must never break gameplay (every call is wrapped + no-ops on failure), and
+**no PII / no 6-digit session code** is ever logged — params are low-cardinality (numbers / bounded
+enums) only.
+
+## Events
+
+GA4 **automatically** collects `page_view`, `session_start`, `first_visit`, device/geo/language, and
+acquisition (referrer + `utm_*`). On top of that we fire custom events:
+
+| Event | Params | Fired in |
+| --- | --- | --- |
+| `session_created` | `connection` (`hybrid`\|`localStorage`) | `network.js` `generateNewSession()` |
+| `controller_arrival` | `method` (`qr`\|`manual_code`) | `controller.js` `initializeMobileController()` |
+| `controller_connected` | `side` (`desktop`\|`phone`) | `network.js` listener (once-guarded) + `controller.js` |
+| `game_start` | — | `game.js` `startGame()` |
+| `game_restart` | — | `game.js` `restartGame()` (covers desktop + phone "Play Again") |
+| `game_over` | `score` (number), `is_high_score` (bool) | `game.js` `gameOver()` |
+| `post_score` | `score` (number) | `game.js` `gameOver()` — GA4 recommended event |
+| `share` | `method` (platform), `content_type` (`score`) | `share.js` `openShare()` |
+| `mute_toggle` | `muted` (bool) | `sound.js` `toggleMute()` |
+| `pwa_install` | `outcome` (`prompted`\|`installed`) | `index.html` install listeners |
+
+Every event also carries `device_role` (`desktop_host` / `phone_controller`).
+
+## How to view the data
+
+1. **Google Analytics** → <https://analytics.google.com> → property **`G-0DFSB38H21`** (or open the
+   **Firebase console → Analytics** for the same data).
+2. **Realtime** report and **DebugView** (Admin → DebugView) show hits within seconds — best for
+   confirming events fire. Standard reports (Audience / Acquisition / Engagement → Events) populate
+   over a few hours; geo/audience builds over a day or two.
+3. Useful reports: **Reports → Acquisition** (traffic sources + campaigns), **Reports → Engagement →
+   Events** (the custom events above), and **Explore** to segment by the `device_role` dimension.
+
+## Marketing campaigns (UTM)
+
+GA4 auto-parses `utm_source / utm_medium / utm_campaign / utm_term / utm_content` from the landing
+URL — **no code needed**. Tag the links you publish, e.g.:
+
+```
+https://go-console-84748.web.app/?utm_source=instagram&utm_medium=bio&utm_campaign=launch
+```
+
+Acquisition reports then attribute sessions — and the `game_over` / `share` engagement — to each
+campaign. UTM params coexist with the controller deep link (`?session=...&utm_source=...`; the app
+reads only `session`).
+
+## Keep dev traffic out of the numbers
+
+Don't gate analytics in code (that would also suppress local verification hits). Instead, in **GA4
+Admin** add an *internal-traffic* rule (by your IP) or a data filter that excludes the dev hostname,
+or use a separate **Dev** data stream.
+
+## Verifying locally
+
+Serve `public/` and watch the network for `https://www.google-analytics.com/g/collect` requests — the
+query string shows `en=<event>` and `ep.device_role=...` for single events (rapid events are batched
+into the POST body). `gtag/js?id=G-0DFSB38H21` loading + the `analytics` handle being defined confirm
+wiring even when an ad-blocker drops the `/collect` beacons. (`204` + `ERR_ABORTED` is normal for the
+keep-alive beacons; GA still receives them.)

--- a/.agent/system/architecture.md
+++ b/.agent/system/architecture.md
@@ -10,6 +10,8 @@ deployed via Firebase Hosting. Live: https://go-console-84748.web.app/
 - **Realtime backend:** Firebase (v8 compat SDK) — **Firestore** for session metadata / game state /
   actions, **Realtime Database** for the high-frequency joystick stream. `localStorage` fallback for
   single-device use.
+- **Analytics:** Firebase Analytics (GA4) via a hardened `trackEvent()` wrapper — see
+  `.agent/system/analytics.md`.
 - **Delivery:** PWA (installable, network-first service worker) on Firebase Hosting.
 
 ## Two roles, one page
@@ -44,7 +46,9 @@ CSS load order: `variables.css` (tokens) → `base.css` → `desktop.css` / `mob
 ## Data flow
 Phone writes joystick input (RTDB) + start/restart (Firestore); desktop listens and runs physics.
 Direction is **continuous (radians), not 4-way**, and speed scales with joystick magnitude. Eating
-within `gameConfig.comboWindowMs` builds a combo multiplier (capped at `maxCombo`).
+within `gameConfig.comboWindowMs` builds a combo multiplier (capped at `maxCombo`). User actions also
+emit GA4 events through `trackEvent()` (a no-op when analytics is unavailable); see
+`.agent/system/analytics.md`.
 
 ## Design principles
 1. **Separation of concerns** — input (`controller.js`), sync (`network.js`), simulation (`game.js`),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,11 +57,22 @@ joystick input (RTDB) + actions (Firestore). Mobile captures the joystick and wr
 scales with joystick magnitude. Eating again within `gameConfig.comboWindowMs` builds a combo
 multiplier (capped at `maxCombo`), surfaced as a draining yellow badge over the board.
 
+**Analytics (GA4).** Firebase Analytics loads alongside the other SDKs; `config.js` creates a
+guarded `analytics` handle (its **own** try/catch so an analytics failure never drops the app into
+offline mode). Everything goes through one helper — `trackEvent(name, params)` in `utils.js` — which
+**no-ops when analytics is unavailable** (ad-block / offline) and **never throws into gameplay**,
+auto-tagging every event with `device_role` (`desktop_host` vs `phone_controller`). Custom events
+span the funnel (`session_created`, `controller_arrival`, `controller_connected`,
+`game_start`/`game_restart`, `game_over`/`post_score`, `share`, `mute_toggle`, `pwa_install`); GA4
+auto-captures audience + `utm_*` acquisition. **Never log PII or the 6-digit session code.** Full
+reference + how to view: `.agent/system/analytics.md`.
+
 ### File roles (`public/`)
-- `js/utils.js` — small shared helpers.
+- `js/utils.js` — small shared helpers, incl. `trackEvent()` (the hardened GA4 analytics wrapper).
 - `js/logic.js` — **pure, testable** game math: joystick→angle/speed mapping, collision, turn step.
   Unit-tested in `tests/` (the only code with real coverage).
-- `js/config.js` — Firebase init + all tunables (`gameConfig`) + `colors` + `GameState` enum.
+- `js/config.js` — Firebase init (incl. the guarded `analytics` / GA4 handle) + all tunables
+  (`gameConfig`) + `colors` + `GameState` enum.
 - `js/state.js` — the global mutable state objects.
 - `js/leaderboard.js` — **local** high-score tracking via `localStorage`. **Not** a global/Firestore
   leaderboard (despite the name — that was scoped but never built).
@@ -94,6 +105,10 @@ multiplier (capped at `maxCombo`), surfaced as a draining yellow badge over the 
   not fully captured in version control.
 - Everything shares global scope — renaming a function or variable can silently break a consumer
   in another file.
+- **ESLint `no-unused-vars` false positives** are expected for the cross-file globals declared in
+  `config.js` (`app`, `database`, `firestore`, `analytics`, `firebaseReady`): they're consumed in
+  *other* files, but ESLint lints each file alone. They're **warnings** (the lint command still
+  exits 0), and `no-undef` is already `off` for the consumer side — safe to ignore.
 - The PWA **service worker is network-first**, so online users always get fresh code — but an
   already-installed SW still needs one reload to update after a deploy. When you change shell
   assets, bump `const CACHE` in `sw.js`. (Local preview can serve stale assets; see

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Scan a QR code and your phone becomes a wireless, analog joystick.
 - 🤳 **Flex your score** — share to WhatsApp, X, Facebook, or Instagram straight from your phone.
 - ⚡ **Offline-ready PWA** — installable, with a network-first service worker.
 - 🛟 **Single-device fallback** — a `localStorage` mode kicks in automatically when Firebase isn't available.
+- 📊 **Audience analytics** — Google Analytics 4 for audience + campaign insight, tagged desktop-host vs. phone-controller. IP-anonymized, and it never blocks gameplay.
 
 ---
 
@@ -52,7 +53,7 @@ Scan a QR code and your phone becomes a wireless, analog joystick.
 
 ## 🛠️ Tech
 
-Vanilla **JavaScript** (no bundler, no modules) · HTML5 **Canvas** · **Firebase** Firestore *(session + game state)* + Realtime Database *(joystick stream)* · **PWA** *(installable, offline shell)* · **Firebase Hosting** with auto-deploy via GitHub Actions.
+Vanilla **JavaScript** (no bundler, no modules) · HTML5 **Canvas** · **Firebase** Firestore *(session + game state)* + Realtime Database *(joystick stream)* + **Analytics (GA4)** · **PWA** *(installable, offline shell)* · **Firebase Hosting** with auto-deploy via GitHub Actions.
 
 ---
 


### PR DESCRIPTION
Documents the analytics shipped in #14. Documentation only — no code/behavior changes.

## Changes
- **README.md** — analytics added to **Features** and **Tech**.
- **CLAUDE.md** — `config.js` (guarded `analytics` handle) and `utils.js` (`trackEvent`) roles updated; a new **Analytics (GA4)** architecture paragraph (the `trackEvent` no-op/never-throw contract, `device_role` tagging, the event list); and a gotcha recording the **expected cross-file `no-unused-vars` ESLint warnings** as safe.
- **.agent/system/architecture.md** — GA4 added to the stack + data flow.
- **.agent/system/analytics.md** *(new)* — the full reference: event taxonomy, **how to view the data in GA4** (Realtime / DebugView / reports), **UTM** campaign tagging, excluding dev traffic, and local verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)