### PR TITLE
feat(haptics): buzz + on-screen flash when the player loses

### DIFF
--- a/public/css/mobile.css
+++ b/public/css/mobile.css
@@ -333,6 +333,22 @@
     box-shadow: var(--shadow-lg);
 }
 
+/* Loss cue: a quick shake + red danger flash on the game-over card (iOS-safe; the
+   on-screen counterpart to the haptic buzz). Re-armed via reflow in playLossFlash(). */
+@keyframes lossShake {
+    0%   { transform: translateX(0);     border-color: rgba(var(--color-red-400-rgb), 0.4); }
+    15%  { transform: translateX(-10px); box-shadow: 0 0 28px 4px rgba(var(--color-red-400-rgb), 0.55); }
+    30%  { transform: translateX(9px); }
+    45%  { transform: translateX(-7px);  border-color: rgba(var(--color-red-400-rgb), 0.85); }
+    60%  { transform: translateX(5px); }
+    75%  { transform: translateX(-3px); }
+    100% { transform: translateX(0);     border-color: rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.4); }
+}
+
+.mobile-game-over-content.loss-flash {
+    animation: lossShake 480ms var(--ease-standard) both;
+}
+
 .mobile-go-title {
     font-family: 'Orbitron', var(--font-family-base);
     color: var(--color-primary);

--- a/public/js/controller.js
+++ b/public/js/controller.js
@@ -220,22 +220,63 @@ function handleCenterButtonPress() {
 // Tracks the last feedback event we vibrated for, so repeated snapshot
 // deliveries of the same event don't buzz more than once.
 let lastFeedbackAt = 0;
+// Tracks the last synced game state so the loss reaction (haptic + flash) fires
+// exactly ONCE per loss, not on every snapshot. Re-arms when a new game starts.
+let lastSyncedState = null;
 
 /**
- * Vibrate the phone in response to a feedback event from the desktop host.
- * Vibration is supported mainly on Android; elsewhere this is a no-op.
+ * Fire a haptic buzz on the phone — cross-platform and best-effort. Never throws.
+ *   • Android (Chrome/Firefox): the real Vibration API.
+ *   • iOS Safari: navigator.vibrate has NEVER existed, so we fall back to the hidden
+ *     <input switch> trick (Safari 17.4+). Apple patched *programmatic* triggering in
+ *     iOS 26.5, so there (and on unsupported browsers) this is a harmless no-op — the
+ *     on-screen .loss-flash cue is what covers iPhones.
+ * Independent of the audio mute by design: a silenced player still feels the loss.
+ * @param {number|number[]} pattern - ms, or an on/off pattern array.
+ */
+function triggerHaptic(pattern) {
+    try {
+        if (typeof navigator.vibrate === 'function') { navigator.vibrate(pattern); return; }
+        const label = document.createElement('label');
+        label.setAttribute('aria-hidden', 'true');
+        label.style.cssText = 'position:absolute;width:1px;height:1px;overflow:hidden;opacity:0;pointer-events:none;';
+        const sw = document.createElement('input');
+        sw.type = 'checkbox';
+        sw.setAttribute('switch', '');
+        label.appendChild(sw);
+        document.body.appendChild(label);
+        try { label.click(); } finally { label.remove(); }
+    } catch (e) {
+        /* haptics must never throw into gameplay */
+    }
+}
+
+/**
+ * Phone-side haptic for a one-shot feedback event from the desktop host (food only;
+ * the loss buzz is driven off the GAME_OVER transition in updateMobileGameOver).
  * @param {{type:string, at:number}} feedback
  */
 function handleHapticFeedback(feedback) {
     if (!feedback || typeof feedback.at !== 'number' || feedback.at === lastFeedbackAt) return;
     lastFeedbackAt = feedback.at;
+    if (feedback.type === 'food') triggerHaptic(40);
+}
 
-    if (!('vibrate' in navigator)) return;
-    if (feedback.type === 'crash') {
-        navigator.vibrate([100, 50, 100]);
-    } else if (feedback.type === 'food') {
-        navigator.vibrate(40);
-    }
+/**
+ * Brief shake + red danger flash on the game-over card — the iOS-safe loss cue (works
+ * where haptics can't). Re-triggers reliably by forcing a reflow before re-adding the
+ * class, and self-cleans on animationend.
+ * @param {HTMLElement} card - the #mobile-game-over element.
+ */
+function playLossFlash(card) {
+    const target = card.querySelector('.mobile-game-over-content') || card;
+    target.classList.remove('loss-flash');
+    void target.offsetWidth; // force reflow so the animation restarts from frame 0
+    target.classList.add('loss-flash');
+    target.addEventListener('animationend', function handler() {
+        target.classList.remove('loss-flash');
+        target.removeEventListener('animationend', handler);
+    });
 }
 
 function connectToSession(sessionCode) {
@@ -442,9 +483,18 @@ function updateMobileGameOver(gs) {
         const scoreEl = document.getElementById('mobile-final-score');
         if (scoreEl) scoreEl.textContent = (typeof gs.score === 'number' ? gs.score : gameState.score).toString();
         card.classList.remove('hidden');
+
+        // React ONCE per loss: a strong "you lost" buzz + an on-screen shake/flash.
+        // Driven off the state edge so it works in BOTH Firebase and localStorage modes.
+        if (lastSyncedState !== GameState.GAME_OVER) {
+            triggerHaptic([120, 60, 120, 60, 240]);
+            playLossFlash(card);
+        }
     } else {
         card.classList.add('hidden');
     }
+
+    lastSyncedState = gs.state;
 }
 
 // ==========================================

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -572,7 +572,6 @@ function gameOver() {
     console.log('💀 Game over! Final score:', gameState.score, 'Snake length:', gameState.snake.length);
     gameState.currentState = GameState.GAME_OVER;
     playCrashSound();
-    sendHapticFeedback('crash');
 
     // Juice: screen shake + a debris burst at the head for crash impact.
     triggerShake(9, 340);


### PR DESCRIPTION
Makes the phone **react when the player loses** — a haptic buzz where the platform allows it, plus an on-screen cue that works everywhere (including iPhone).

## Why
A partial haptic existed (desktop sent a `feedback:'crash'` → phone `navigator.vibrate`), but it only worked on Android. The owner is on **iPhone**, where it can never fire: iOS Safari has **no Vibration API**, and the one workaround (toggling a hidden `<input type="checkbox" switch>`) was **patched by Apple in iOS 26.5** for programmatic use. So vibration alone leaves iPhones with nothing.

## What changed
Driven off the **authoritative `GAME_OVER` state transition** on the phone (so it works in **both** Firebase and single-device/localStorage modes, fires **exactly once** per loss, and re-arms on replay):

- **`triggerHaptic()`** — cross-platform buzz: `navigator.vibrate([120,60,120,60,240])` on Android, with a **best-effort iOS** `<input switch>` fallback (a harmless no-op on iOS 26.5+ and unsupported browsers). Never throws into gameplay; intentionally **independent of the audio mute**.
- **On-screen "you lost" cue** — a shake + red danger flash of the phone's game-over card (`.loss-flash`), the reliable feedback for iPhones. On-theme (red is a transient accent over the teal card).
- Removed the now-redundant `sendHapticFeedback('crash')` from `gameOver()` to avoid a **double-buzz**; `handleHapticFeedback` now handles **food** only (routed through `triggerHaptic`).

Files: `public/js/controller.js`, `public/js/game.js`, `public/css/mobile.css`. No changes to network/state/config/sw.

## ⚠️ iPhone reality
Real vibration **cannot** be triggered from a web page on a current iPhone (Apple's iOS 26.5 restriction). On iPhone you'll get the **shake/flash** cue; the buzz lands on **Android** (and best-effort iOS ≤26.4).

## Verification (Python http.server + Claude_Preview, controller view; eval-based)
- First loss → vibrates once with `[120,60,120,60,240]`, card shown, `.loss-flash` applied, `animationName: lossShake`.
- Repeat snapshot → **no** re-buzz (transition guard). Replay → buzzes again.
- `gameOver()` no longer sends `'crash'` (no double-buzz); food haptic still fires once (deduped).
- iOS fallback path (vibrate undefined) → does not throw; hidden switch created+removed cleanly.
- Zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)