### PR TITLE
feat(leaderboard): global Firestore leaderboard with handles + trophy modal

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -18,6 +18,27 @@ service cloud.firestore {
       allow create, update: if code.matches('^[0-9]{6}$') && validShape();
     }
 
+    // Public global leaderboard — one row per device id (the doc id). Reads are open so
+    // anyone can view the board; writes are shape + range validated and monotonic (a score
+    // can only go up). Best-effort only: with no auth, a determined client can still submit
+    // a fake in-range score. Real anti-cheat needs server validation / Firebase App Check.
+    match /leaderboard/{playerId} {
+      function validLeaderboard(data) {
+        return data.keys().hasOnly(['name', 'score', 'updatedAt'])
+          && data.name is string
+          && data.name.size() >= 1 && data.name.size() <= 16
+          && data.score is number
+          && data.score >= 0 && data.score <= 100000
+          && data.updatedAt == request.time;
+      }
+
+      allow read: if true;
+      allow create: if validLeaderboard(request.resource.data);
+      allow update: if validLeaderboard(request.resource.data)
+                    && request.resource.data.score >= resource.data.score;
+      allow delete: if false;
+    }
+
     // Everything else is denied by default (no other match blocks grant access).
   }
 }

--- a/public/css/leaderboard.css
+++ b/public/css/leaderboard.css
@@ -1,0 +1,140 @@
+/* ==========================================
+   GLOBAL LEADERBOARD — modal + game-over rank
+   ========================================== */
+
+.leaderboard-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-20);
+    background: rgba(0, 0, 0, 0.55);
+    backdrop-filter: blur(10px);
+}
+
+.leaderboard-panel {
+    position: relative;
+    width: min(440px, 92vw);
+    max-height: 80vh;
+    overflow-y: auto;
+    padding: var(--space-32);
+    background: linear-gradient(135deg,
+        rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.15),
+        rgba(var(--color-teal-700-rgb, var(--color-teal-700)), 0.15));
+    border: 2px solid rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.5);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+    text-align: center;
+    color: var(--color-text);
+}
+
+.leaderboard-panel h2 {
+    font-family: 'Orbitron', var(--font-family-base);
+    color: var(--color-primary);
+    margin-bottom: var(--space-20);
+}
+
+.lb-close {
+    position: absolute;
+    top: var(--space-12);
+    right: var(--space-16);
+    background: none;
+    border: none;
+    color: var(--color-text);
+    font-size: var(--font-size-3xl);
+    line-height: 1;
+    cursor: pointer;
+}
+
+.lb-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    text-align: left;
+}
+
+.lb-row {
+    display: grid;
+    grid-template-columns: 3rem 1fr auto;
+    gap: var(--space-12);
+    align-items: center;
+    padding: var(--space-12) var(--space-16);
+    border-bottom: 1px solid rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.2);
+}
+
+.lb-row .lb-rank {
+    color: var(--color-warning);
+    font-weight: var(--font-weight-bold);
+}
+
+.lb-row .lb-name {
+    color: var(--color-text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.lb-row .lb-score {
+    color: var(--color-primary);
+    font-weight: var(--font-weight-bold);
+    font-family: 'Orbitron', var(--font-family-base);
+}
+
+.lb-me {
+    background: rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.22);
+    border-radius: var(--radius-base);
+}
+
+.lb-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-8);
+}
+
+.lb-state {
+    color: var(--color-text-secondary);
+    padding: var(--space-20) 0;
+}
+
+/* Game-over additions */
+.global-rank {
+    color: var(--color-primary);
+    font-weight: var(--font-weight-bold);
+    margin: var(--space-12) 0 0;
+    text-shadow: 0 0 8px rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.6);
+}
+
+.name-entry {
+    margin-top: var(--space-16);
+}
+
+.name-entry .input-group {
+    margin-bottom: var(--space-12);
+}
+
+/* The shared .input-group input spaces digits wide for the 6-digit code; tighten it for names. */
+#player-name {
+    letter-spacing: 0.05em;
+}
+
+.lb-invalid {
+    border-color: var(--color-error) !important;
+}
+
+/* Trophy button — matches the .social-link sizing from desktop.css */
+.social-link.leaderboard-link {
+    background: linear-gradient(45deg, var(--color-warning), var(--color-teal-600));
+    color: var(--color-surface);
+    border: none;
+    cursor: pointer;
+    box-shadow: var(--shadow-md);
+}
+
+.social-link.leaderboard-link:hover {
+    background: linear-gradient(45deg, var(--color-teal-600), var(--color-warning));
+    transform: translateY(-3px) scale(1.05);
+    box-shadow: var(--shadow-lg);
+}

--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="css/base.css">
     <link rel="stylesheet" href="css/desktop.css">
     <link rel="stylesheet" href="css/mobile.css">
+    <link rel="stylesheet" href="css/leaderboard.css">
     
     <!-- Favicon -->
     <link rel="icon" type="image/png" sizes="32x32" href="snake-favicon.png">
@@ -106,6 +107,9 @@
                     <button id="mute-btn" class="social-link mute-link" type="button" aria-label="Mute sound">
                         <i class="fas fa-volume-high"></i>
                     </button>
+                    <button id="leaderboard-btn" class="social-link leaderboard-link" type="button" aria-label="View leaderboard">
+                        <i class="fas fa-trophy"></i>
+                    </button>
                 </div>
             </div>
 
@@ -125,6 +129,14 @@
                                 <span id="final-score" class="score-value">0</span>
                             </div>
                             <p id="new-high-score" class="new-high-score hidden">🏆 New High Score!</p>
+                            <p id="global-rank" class="global-rank hidden"></p>
+                            <div id="name-entry" class="name-entry hidden">
+                                <div class="input-group">
+                                    <label for="player-name">Join the leaderboard</label>
+                                    <input type="text" id="player-name" maxlength="16" placeholder="Your name" autocomplete="off">
+                                </div>
+                                <button id="join-leaderboard-btn" class="btn btn-connect" type="button">Join</button>
+                            </div>
                             <p class="restart-prompt">Press Space to play again · or use your phone</p>
                         </div>
                     </div>
@@ -169,6 +181,18 @@
                         </p>
                     </div>
                 </div>
+            </div>
+        </div>
+
+        <!-- Global leaderboard modal (desktop host) -->
+        <div id="leaderboard-modal" class="leaderboard-modal hidden" role="dialog" aria-modal="true" aria-labelledby="lb-title">
+            <div class="leaderboard-panel">
+                <button id="lb-close" class="lb-close" type="button" aria-label="Close">&times;</button>
+                <h2 id="lb-title">🏆 Global Leaderboard</h2>
+                <div id="lb-loading" class="lb-loading"><div class="loading-spinner"></div><p>Loading…</p></div>
+                <ol id="lb-list" class="lb-list hidden"></ol>
+                <p id="lb-empty" class="lb-state hidden">Be the first on the board!</p>
+                <p id="lb-error" class="lb-state hidden">Leaderboard unavailable right now.</p>
             </div>
         </div>
     </div>
@@ -240,6 +264,7 @@
     <script src="js/config.js"></script>
     <script src="js/state.js"></script>
     <script src="js/leaderboard.js"></script>
+    <script src="js/leaderboard-ui.js"></script>
     <script src="js/sound.js"></script>
     <script src="js/effects.js"></script>
     <script src="js/network.js"></script>

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -62,6 +62,9 @@ const activeDirectionKeys = new Set();
  */
 function setupKeyboardControls() {
     document.addEventListener('keydown', (e) => {
+        // Don't hijack Space/Enter while typing a leaderboard handle in the game-over field.
+        const active = document.activeElement;
+        if (active && (active.id === 'player-name' || active.tagName === 'INPUT')) return;
         const key = e.key.toLowerCase();
 
         if (key === ' ' || key === 'enter') {
@@ -593,6 +596,13 @@ function gameOver() {
     const newHighEl = document.getElementById('new-high-score');
     if (newHighEl) newHighEl.classList.toggle('hidden', !isNewBest);
 
+    // Global leaderboard: submit if we already have a handle, else prompt for one.
+    if (typeof getPlayerName === 'function' && getPlayerName()) {
+        submitAndShowRank(gameState.score);
+    } else if (typeof showNameEntry === 'function') {
+        showNameEntry(gameState.score);
+    }
+
     // Analytics: the run's score + whether it set a new personal best. post_score is a
     // GA4-recommended event that surfaces in the Games engagement reports.
     trackEvent('game_over', { score: gameState.score, is_high_score: isNewBest });
@@ -606,6 +616,49 @@ function gameOver() {
     }
 
     updateGameStateInFirebase();
+}
+
+/**
+ * Submit the run's score to the global leaderboard, then show the rank callout.
+ * Non-blocking; degrades to "Leaderboard unavailable" and never throws into gameplay.
+ * @param {number} score
+ */
+function submitAndShowRank(score) {
+    const callout = document.getElementById('global-rank');
+    if (callout) { callout.classList.remove('hidden'); callout.textContent = 'Submitting to leaderboard…'; }
+    Promise.resolve(submitGlobalScore(score)).then((rank) => {
+        if (!callout) return;
+        if (rank) {
+            callout.textContent = `You ranked #${rank} globally 🏆`;
+            trackEvent('leaderboard_submit', { score: score, rank: rank });
+        } else {
+            callout.textContent = 'Leaderboard unavailable';
+        }
+    }).catch(() => { if (callout) callout.textContent = 'Leaderboard unavailable'; });
+}
+
+/**
+ * Reveal the name-entry field on game-over when no handle is saved yet; submit on confirm.
+ * @param {number} score
+ */
+function showNameEntry(score) {
+    const entry = document.getElementById('name-entry');
+    const input = document.getElementById('player-name');
+    const callout = document.getElementById('global-rank');
+    if (callout) callout.classList.add('hidden');
+    if (!entry || !input) return;
+    entry.classList.remove('hidden');
+    input.value = '';
+    setTimeout(() => input.focus(), 50);
+    const confirmName = () => {
+        const saved = setPlayerName(input.value);
+        if (!saved) { input.classList.add('lb-invalid'); return; }
+        entry.classList.add('hidden');
+        submitAndShowRank(score);
+    };
+    const joinBtn = document.getElementById('join-leaderboard-btn');
+    if (joinBtn) joinBtn.onclick = confirmName;
+    input.onkeydown = (e) => { if (e.key === 'Enter') { e.preventDefault(); e.stopPropagation(); confirmName(); } };
 }
 
 /**

--- a/public/js/leaderboard-ui.js
+++ b/public/js/leaderboard-ui.js
@@ -1,0 +1,74 @@
+// ==========================================
+// LEADERBOARD MODAL (desktop host UI)
+// ==========================================
+// Opens the global Top-N board. Degrades to an "unavailable" state when Firebase is down
+// or the rules aren't deployed yet. Handles are rendered with textContent (XSS-safe).
+
+function openLeaderboard() {
+    const modal = document.getElementById('leaderboard-modal');
+    if (!modal) return;
+    modal.classList.remove('hidden');
+    trackEvent('leaderboard_view');
+    renderLeaderboard();
+}
+
+function closeLeaderboard() {
+    const modal = document.getElementById('leaderboard-modal');
+    if (modal) modal.classList.add('hidden');
+}
+
+function lbToggle(id, on) {
+    const el = document.getElementById(id);
+    if (el) el.classList.toggle('hidden', !on);
+}
+
+async function renderLeaderboard() {
+    lbToggle('lb-loading', true);
+    lbToggle('lb-list', false);
+    lbToggle('lb-empty', false);
+    lbToggle('lb-error', false);
+
+    // Offline / Firebase down / rules not deployed → show "unavailable", never throw.
+    if (typeof firestore === 'undefined' || !firebaseReady || !firestore) {
+        lbToggle('lb-loading', false);
+        lbToggle('lb-error', true);
+        return;
+    }
+
+    const rows = await fetchTopScores(10);
+    lbToggle('lb-loading', false);
+    if (!rows.length) { lbToggle('lb-empty', true); return; }
+
+    const me = (typeof getPlayerId === 'function') ? getPlayerId() : null;
+    const list = document.getElementById('lb-list');
+    if (!list) return;
+    list.innerHTML = '';
+    rows.forEach((row, i) => {
+        const li = document.createElement('li');
+        li.className = 'lb-row' + (row.id === me ? ' lb-me' : '');
+        const rank = document.createElement('span');
+        rank.className = 'lb-rank';
+        rank.textContent = '#' + (i + 1);
+        const name = document.createElement('span');
+        name.className = 'lb-name';
+        name.textContent = row.name;
+        const score = document.createElement('span');
+        score.className = 'lb-score';
+        score.textContent = row.score;
+        li.append(rank, name, score);
+        list.appendChild(li);
+    });
+    lbToggle('lb-list', true);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const btn = document.getElementById('leaderboard-btn');
+    const closeBtn = document.getElementById('lb-close');
+    const modal = document.getElementById('leaderboard-modal');
+    if (btn) btn.addEventListener('click', openLeaderboard);
+    if (closeBtn) closeBtn.addEventListener('click', closeLeaderboard);
+    if (modal) modal.addEventListener('click', (e) => { if (e.target === modal) closeLeaderboard(); });
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && modal && !modal.classList.contains('hidden')) closeLeaderboard();
+    });
+});

--- a/public/js/leaderboard.js
+++ b/public/js/leaderboard.js
@@ -54,3 +54,112 @@ function updateHighScoreDisplay() {
     const el = document.getElementById('high-score');
     if (el) el.textContent = getHighScore().toString();
 }
+
+// ==========================================
+// GLOBAL LEADERBOARD (Firestore)
+// ==========================================
+// Public board keyed by a stable per-device id, so each device is one row. Reads are
+// public; writes are shape/score-validated in firestore.rules — which the owner must
+// deploy (`firebase deploy --only firestore:rules`) before writes are accepted. Every
+// call is guarded + try/caught so it can never throw into gameplay.
+
+const LB_COLLECTION = 'leaderboard';
+const PLAYER_ID_KEY = 'snake_player_id';
+const PLAYER_NAME_KEY = 'snake_player_name';
+const LB_BEST_KEY = 'snake_lb_best'; // highest score already submitted (skip redundant writes)
+const LB_SCORE_CEILING = 100000;
+
+/** Stable per-device id, generated once and persisted. */
+function getPlayerId() {
+    let id = localStorage.getItem(PLAYER_ID_KEY);
+    if (id) return id;
+    id = (window.crypto && crypto.randomUUID)
+        ? crypto.randomUUID()
+        : 'p-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 10);
+    try { localStorage.setItem(PLAYER_ID_KEY, id); } catch (e) { /* private mode */ }
+    return id;
+}
+
+/** @returns {string} The saved handle, or '' if none. */
+function getPlayerName() {
+    return localStorage.getItem(PLAYER_NAME_KEY) || '';
+}
+
+/**
+ * Persist a sanitized handle.
+ * @param {string} name
+ * @returns {string} The stored value, or '' if the input was rejected.
+ */
+function setPlayerName(name) {
+    const clean = sanitizeName(name);
+    if (!clean) return '';
+    try { localStorage.setItem(PLAYER_NAME_KEY, clean); } catch (e) { /* ignore */ }
+    return clean;
+}
+
+/**
+ * Upsert this device's row when `score` beats our last submission. Resolves to the
+ * player's global rank (number) or null on any failure/no-op. Never throws.
+ * @param {number} score
+ * @returns {Promise<number|null>}
+ */
+async function submitGlobalScore(score) {
+    try {
+        if (typeof firestore === 'undefined' || !firebaseReady || !firestore) return null;
+        const name = getPlayerName();
+        if (typeof score !== 'number' || score <= 0 || score > LB_SCORE_CEILING || !name) return null;
+
+        const prevBest = Number(localStorage.getItem(LB_BEST_KEY)) || 0;
+        if (score <= prevBest) return await getPlayerRank(score); // already submitted higher/equal
+
+        await firestore.collection(LB_COLLECTION).doc(getPlayerId()).set({
+            name: name,
+            score: score,
+            updatedAt: firebase.firestore.FieldValue.serverTimestamp()
+        }, { merge: true });
+
+        try { localStorage.setItem(LB_BEST_KEY, String(score)); } catch (e) { /* ignore */ }
+        return await getPlayerRank(score);
+    } catch (error) {
+        console.warn('submitGlobalScore failed (are the leaderboard rules deployed?):', error);
+        return null;
+    }
+}
+
+/**
+ * Top-N rows, highest first.
+ * @param {number} [n=10]
+ * @returns {Promise<Array<{id:string, name:string, score:number}>>} [] on failure.
+ */
+async function fetchTopScores(n = 10) {
+    try {
+        if (typeof firestore === 'undefined' || !firebaseReady || !firestore) return [];
+        const snap = await firestore.collection(LB_COLLECTION)
+            .orderBy('score', 'desc').limit(n).get();
+        return snap.docs.map((d) => {
+            const data = d.data() || {};
+            return { id: d.id, name: data.name || '—', score: Number(data.score) || 0 };
+        });
+    } catch (error) {
+        console.warn('fetchTopScores failed:', error);
+        return [];
+    }
+}
+
+/**
+ * Global rank for a score = (rows strictly above it) + 1. One read; reuses the single
+ * `score` index.
+ * @param {number} score
+ * @returns {Promise<number|null>}
+ */
+async function getPlayerRank(score) {
+    try {
+        if (typeof firestore === 'undefined' || !firebaseReady || !firestore) return null;
+        const snap = await firestore.collection(LB_COLLECTION)
+            .where('score', '>', score).get();
+        return snap.size + 1;
+    } catch (error) {
+        console.warn('getPlayerRank failed:', error);
+        return null;
+    }
+}

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -40,3 +40,18 @@ function trackEvent(name, params = {}) {
         /* analytics must never throw into gameplay */
     }
 }
+
+/**
+ * Normalize a leaderboard handle: collapse any whitespace (tabs/newlines → single space),
+ * trim, and clamp to 16 chars. Returns null if nothing valid remains. UX-only — the
+ * firestore.rules re-validate length on the server, and the board renders names with
+ * textContent (so no markup can be injected).
+ * @param {string} raw
+ * @returns {string|null}
+ */
+function sanitizeName(raw) {
+    if (typeof raw !== 'string') return null;
+    const clean = raw.replace(/\s+/g, ' ').trim();
+    if (clean.length < 1) return null;
+    return clean.slice(0, 16);
+}


### PR DESCRIPTION
Promotes the local-only high-score table to a **global, cross-device leaderboard** — players worldwide compete by handle, viewable from a 🏆 modal, with a "You ranked #N globally" callout on game-over.

## 🚨 REQUIRED before it works in production (one-time, owner only)
The new `leaderboard` collection is **denied by the live Firestore rules** until they're deployed — and CI deploys **hosting only** (rules are held). After merge, run once from your machine:
```
firebase deploy --only firestore:rules
```
(or paste the updated `firestore.rules` into Firebase console → Firestore → Rules). **Until then the board ships *inert*:** reads show "Leaderboard unavailable", submits no-op, and the game is otherwise unaffected.

## ⚠️ Best-effort anti-cheat
Rules validate the doc shape, a 0–100000 score range, and monotonic scores (can't lower your best) — but with no auth a determined user could still submit a fake *in-range* score from the real client. True anti-cheat needs server validation; **Firebase App Check** is the recommended future hardening. Normal trade-off for a fun web leaderboard.

## What's included
- **Data layer** (`leaderboard.js`): one row per device keyed by a stable UUID (`snake_player_id`). `submitGlobalScore()` upserts `{name, score, updatedAt}` only when the score beats the device's last submission; `fetchTopScores()` / `getPlayerRank()` read the Top-N + exact rank. All guarded + try/caught — **never throws into gameplay**, degrades to "unavailable" offline.
- **Identity**: a **handle** (no accounts), entered once on the desktop game-over, sanitized (`utils.sanitizeName`, ≤16 chars) and remembered in `localStorage`.
- **UI**: a trophy button → Top-N modal (rank · handle · score; **your row highlighted**; loading/empty/error states; Esc + backdrop close) + the game-over rank callout. New `leaderboard-ui.js` + `leaderboard.css`. Handles render via `textContent` (XSS-safe).
- **`gameOver()`**: submits the score (or prompts for a handle first); a **keydown guard** stops Space/Enter from restarting the game while you type your handle.
- **`firestore.rules`**: `/leaderboard/{playerId}` block (public read; validated, monotonic writes). Analytics: `leaderboard_view`, `leaderboard_submit {score, rank}`.

## Not Google Play Games
GPGS is Android-native-app only — it wouldn't cover desktop/iPhone or a web game, and would force wrapping + publishing an Android app. Firestore works in every browser on every device with no login.

## Verification (Python http.server + Claude_Preview; eval-based — real cross-browser board needs the rules deploy, so Firestore is **stubbed**)
- Data layer: `submitGlobalScore(50)` builds `{name,score,updatedAt}` with a server-timestamp + returns rank `size+1`; redundant-write guard holds (no write when ≤ own best); `sanitizeName` trims/clamps(16)/rejects blanks; `getPlayerId` stable; name persists.
- UI: trophy click + `openLeaderboard` render the Top-N in order with `.lb-me` highlighted, fire `leaderboard_view`, and close via button/Esc/backdrop.
- **Graceful offline path**: `firestore` unset → submit `null`, fetch `[]`, modal → "unavailable", no throws.
- Zero console errors. (Production still needs the rules deploy to accept real writes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)