### PR TITLE
chore: track .claude/launch.json for the local preview server

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "snake",
+      "runtimeExecutable": "python",
+      "runtimeArgs": ["-m", "http.server", "8000", "--directory", "public"],
+      "port": 8000
+    }
+  ]
+}


### PR DESCRIPTION
Commits the `.claude/launch.json` I'd been keeping as a local-only file all session.

It's the **Claude_Preview** MCP config that serves `public/` with Python for local, no-build verification:
```
python -m http.server 8000 --directory public
```
Tracking it so the local preview "just works" for any contributor (and future AI sessions) instead of being a per-machine file. No app/runtime impact — it's tooling config outside `public/`, so it isn't deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)