### PR TITLE
chore(ci): make lint, tests, and syntax checks actually gate the build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,25 +26,21 @@ jobs:
           node-version: '18'
           cache: 'npm'
       
-      - name: 📦 Install Firebase CLI
-        run: npm install -g firebase-tools
-
       - name: 📦 Install dependencies
         run: npm install
 
       - name: 🔎 Lint
         run: npm run lint
-        continue-on-error: true  # TODO: drop continue-on-error once lint is verified green in CI
 
       - name: 🧪 Unit tests
         run: npm test
-        continue-on-error: true  # TODO: drop continue-on-error once tests are verified green in CI
 
       - name: 🔍 Quality Checks
         run: |
           echo "🧪 Running Syntax Checks..."
-          find public -name "*.js" -exec node -c {} \;
-          
+          # xargs propagates node's exit code; the old `find -exec … \;` swallowed it.
+          git ls-files 'public/js/*.js' 'public/*.js' | xargs -n1 node --check
+
           echo "🧪 Running Validation..."
           # Test if HTML is valid and config exists
           grep -q "<!DOCTYPE" public/index.html || (echo "❌ HTML Error" && exit 1)
@@ -56,7 +52,7 @@ jobs:
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         # Rules deploy is HELD until firestore.rules / database.rules.json are tested
         # against a scratch project. To ship rules, restore: --only hosting,firestore,database
-        run: firebase deploy --only hosting --token "${{ secrets.FIREBASE_TOKEN }}" --non-interactive
+        run: npx firebase deploy --only hosting --token "${{ secrets.FIREBASE_TOKEN }}" --non-interactive
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
 


### PR DESCRIPTION
## 🎯 Description
Makes the CI quality gates real. Previously a commit that failed every test and didn't even parse would still deploy to production:
- `Lint` and `Unit tests` ran with `continue-on-error: true`.
- The syntax check used `find -exec node -c {} \;` — find's `\;` form **ignores the exit status** of the executed command, so syntax errors never failed the build.

This PR drops both `continue-on-error` flags, replaces the syntax check with `git ls-files 'public/js/*.js' 'public/*.js' | xargs -n1 node --check` (xargs propagates failure), and removes the redundant global `firebase-tools` install (it's already a devDependency; the deploy step now uses `npx firebase`).

> **Merge order:** PR 1 of a 6-PR stacked chain (`chore/ci-real-gates` → `feature/protocol-smoke-test` → `bugfix/device-role-race` → `refactor/quick-wins` → `chore/rules-deploy-and-docs` → `refactor/lint-and-logging`). Merge this first; later PRs show cumulative diffs until their predecessors land.

## 🎮 Type of Change
- [x] 🔧 Code refactoring (no functional changes)

## 🧪 Testing
No Node on the dev machine — lint/tests were **not** run locally. **This PR's own CI run is the verification:** it is the first run where lint, vitest, and the syntax check can actually fail, so a green check here proves both the gates and the current codebase. Watch with `gh pr checks`.

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code

## 🔧 Breaking Changes
- [x] No breaking changes (deploy step itself is unchanged — still `--only hosting` in this PR)

## 🚀 Deployment Notes
- [x] No special deployment needed
