### PR TITLE
fix(bootstrap): decide the device role once, eliminating the init race

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,25 +26,21 @@ jobs:
           node-version: '18'
           cache: 'npm'
       
-      - name: 📦 Install Firebase CLI
-        run: npm install -g firebase-tools
-
       - name: 📦 Install dependencies
         run: npm install
 
       - name: 🔎 Lint
         run: npm run lint
-        continue-on-error: true  # TODO: drop continue-on-error once lint is verified green in CI
 
       - name: 🧪 Unit tests
         run: npm test
-        continue-on-error: true  # TODO: drop continue-on-error once tests are verified green in CI
 
       - name: 🔍 Quality Checks
         run: |
           echo "🧪 Running Syntax Checks..."
-          find public -name "*.js" -exec node -c {} \;
-          
+          # xargs propagates node's exit code; the old `find -exec … \;` swallowed it.
+          git ls-files 'public/js/*.js' 'public/*.js' | xargs -n1 node --check
+
           echo "🧪 Running Validation..."
           # Test if HTML is valid and config exists
           grep -q "<!DOCTYPE" public/index.html || (echo "❌ HTML Error" && exit 1)
@@ -56,7 +52,7 @@ jobs:
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         # Rules deploy is HELD until firestore.rules / database.rules.json are tested
         # against a scratch project. To ship rules, restore: --only hosting,firestore,database
-        run: firebase deploy --only hosting --token "${{ secrets.FIREBASE_TOKEN }}" --non-interactive
+        run: npx firebase deploy --only hosting --token "${{ secrets.FIREBASE_TOKEN }}" --non-interactive
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "eslint": "^8.57.0",
     "firebase-tools": "^13.0.0",
+    "jsdom": "^24.1.0",
     "prettier": "^3.3.3",
     "vitest": "^1.6.0"
   }

--- a/public/index.html
+++ b/public/index.html
@@ -275,10 +275,6 @@
     
     <!-- Loading screen handler: reveal the app as soon as the page is ready -->
     <script>
-        // A session code in the URL means this device is the controller (mobile) view.
-        const urlParams = new URLSearchParams(window.location.search);
-        const hasSession = urlParams.get('session');
-
         function revealApp() {
             const loadingScreen = document.getElementById('loading-screen');
             const desktopView = document.getElementById('desktop-view');
@@ -287,15 +283,18 @@
             // cssText uses !important to override the media-query CSS at the top of <head>.
             if (loadingScreen) loadingScreen.style.cssText = 'display: none !important';
 
-            const isController = window.innerWidth <= 768 || hasSession;
+            // Purely cosmetic: READ the role decided once by detectDevice() (main.js,
+            // DOMContentLoaded — always before `load`). Never recompute it here, or the
+            // two code paths can race and disagree (wrong view initialized).
+            const isController = typeof sessionManager !== 'undefined'
+                ? !sessionManager.isDesktop
+                : window.innerWidth <= 768;
             if (isController) {
                 if (mobileView) mobileView.style.cssText = 'display: block !important';
                 if (desktopView) desktopView.style.cssText = 'display: none !important';
-                if (typeof sessionManager !== 'undefined') sessionManager.isDesktop = false;
             } else {
                 if (desktopView) desktopView.style.cssText = 'display: block !important';
                 if (mobileView) mobileView.style.cssText = 'display: none !important';
-                if (typeof sessionManager !== 'undefined') sessionManager.isDesktop = true;
             }
         }
 

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -3,11 +3,15 @@
 // ==========================================
 
 /**
- * Validates the resolution layout to decide rendering logic
+ * Decides the device role ONCE for the whole app: a narrow viewport or a
+ * `?session=` URL param (arriving via QR scan) means this device is the
+ * controller. Everything else — including the inline reveal script in
+ * index.html — must READ sessionManager.isDesktop, never recompute it.
  */
 function detectDevice() {
-    const isMobile = window.innerWidth <= 768;
-    sessionManager.isDesktop = !isMobile;
+    const isController = window.innerWidth <= 768 ||
+        new URLSearchParams(window.location.search).has('session');
+    sessionManager.isDesktop = !isController;
 
     // Tag the GA4 session with the device role so the two audiences are segmentable.
     try {
@@ -43,9 +47,11 @@ function initializeApp() {
     }
 }
 
-// Initialize the application
+// Initialize the application. No artificial delay: Firebase init in config.js runs
+// synchronously before DOMContentLoaded, and both session paths already cope with a
+// not-yet-ready Firebase (generateNewSession falls back, connectToSession retries).
 document.addEventListener('DOMContentLoaded', function() {
     console.log('DOM loaded, initializing app...');
     detectDevice();
-    setTimeout(initializeApp, 1000);
+    initializeApp();
 });

--- a/public/sw.js
+++ b/public/sw.js
@@ -5,7 +5,7 @@
 // cache is an OFFLINE FALLBACK only. All cross-origin traffic (Firebase, gstatic, unpkg, Font
 // Awesome) is left untouched so realtime sync keeps working. Bump CACHE when shell assets change.
 
-const CACHE = 'snake-shell-v5';
+const CACHE = 'snake-shell-v6';
 
 const SHELL_ASSETS = [
     './',

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -1,0 +1,162 @@
+// Protocol smoke test — exercises the desktop ↔ controller sync protocol end-to-end
+// through the localStorage fallback mode, with the production scripts UNMODIFIED.
+//
+// Harness: two separate JSDOM windows ("desktop" and "controller"), each loaded with
+// the real index.html markup. The classic <script> files are evaluated into each
+// window's vm context with vm.runInContext, which shares the global *lexical*
+// environment across scripts exactly like sequential <script> tags (a plain eval /
+// new Function approach would not share top-level let/const such as gameState).
+//
+// Browsers fire the 'storage' event only in OTHER documents, so a bridge mirrors
+// every localStorage.setItem into the peer window and dispatches a StorageEvent
+// there — same semantics as two tabs sharing one origin. Delivery is synchronous,
+// so assertions need no async waits.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+import logic from '../public/js/logic.js';
+
+const PUB = join(__dirname, '..', 'public');
+// index.html order, minus main.js (we drive init manually), leaderboard-ui.js and
+// share.js (DOMContentLoaded / typeof-guarded wiring, unused on this path).
+const SCRIPTS = [
+    'utils', 'logic', 'config', 'state', 'leaderboard',
+    'sound', 'effects', 'network', 'game', 'controller',
+].map((n) => join(PUB, 'js', `${n}.js`));
+const HTML = readFileSync(join(PUB, 'index.html'), 'utf8');
+
+const SESSION = '123456';
+
+function makePage() {
+    // A real url is required or window.localStorage throws (opaque origin).
+    const dom = new JSDOM(HTML, { runScripts: 'outside-only', url: 'https://snake.test/' });
+    const ctx = dom.getInternalVMContext();
+    // Force offline mode WITHOUT config.js's retry timer: `firebase` is defined, so
+    // initializeFirebase() runs once, initializeApp throws, and the catch settles
+    // with firebaseReady = false.
+    ctx.firebase = { initializeApp() { throw new Error('offline (test stub)'); } };
+    for (const f of SCRIPTS) {
+        vm.runInContext(readFileSync(f, 'utf8'), ctx, { filename: f });
+    }
+    // Top-level let/const live in the context's global lexical env — readable only
+    // by evaluating code inside the context, not as properties on `ctx`.
+    return { dom, run: (code) => vm.runInContext(code, ctx) };
+}
+
+// Mirror each window's localStorage writes into the peer and fire a StorageEvent
+// there. Patch Storage.prototype (NOT the instance — Storage's spec'd named-property
+// setter would turn an instance `setItem` assignment into a stored item), and have
+// each side call the peer's saved ORIGINAL to avoid infinite ping-pong.
+function bridgeStorage(a, b) {
+    const pa = a.dom.window.Storage.prototype;
+    const pb = b.dom.window.Storage.prototype;
+    const origA = pa.setItem;
+    const origB = pb.setItem;
+    const deliver = (page, orig, key, value) => {
+        const w = page.dom.window;
+        const oldValue = w.localStorage.getItem(key);
+        orig.call(w.localStorage, key, String(value));
+        w.dispatchEvent(new w.StorageEvent('storage', {
+            key, oldValue, newValue: String(value), storageArea: w.localStorage,
+        }));
+    };
+    pa.setItem = function (k, v) { origA.call(this, k, v); deliver(b, origB, k, v); };
+    pb.setItem = function (k, v) { origB.call(this, k, v); deliver(a, origA, k, v); };
+}
+
+describe('desktop ↔ controller protocol (localStorage fallback mode)', () => {
+    let desktop, controller;
+    const $ = (page, sel) => page.dom.window.document.querySelector(sel);
+
+    beforeAll(() => {
+        desktop = makePage();
+        controller = makePage();
+        bridgeStorage(desktop, controller);
+
+        // Desktop host side (what generateNewSession does, minus QR/Firebase).
+        desktop.run(`sessionManager.currentSession = '${SESSION}';`);
+        desktop.run(`setupLocalStorageSession('${SESSION}');`);
+
+        // Controller side. firebaseReady is false, so attemptConnection goes straight
+        // to connectViaLocalStorage, which reads the mirrored 'currentSession' key.
+        controller.run('sessionManager.isDesktop = false;');
+        controller.run(`connectToSession('${SESSION}');`);
+    });
+
+    afterAll(() => {
+        // Clears pending timers (gameOver's 150ms hitstop, name-entry focus) so
+        // vitest can exit.
+        desktop.dom.window.close();
+        controller.dom.window.close();
+    });
+
+    it('connects the controller and shows the ready state', () => {
+        expect(controller.run('sessionManager.connectedSession')).toBe(SESSION);
+        expect(controller.run('sessionManager.connectionType')).toBe('localStorage');
+        expect($(controller, '#connection-form').style.display).toBe('none');
+        expect($(controller, '#controller-interface').style.display).toBe('block');
+        expect($(controller, '#btn-center .center-icon').textContent).toBe('▶');
+        expect($(controller, '#btn-center').disabled).toBe(false);
+        expect($(controller, '#mobile-game-over').classList.contains('hidden')).toBe(true);
+        expect(desktop.run('gameState.currentState')).toBe('waiting_for_start');
+    });
+
+    it('ignores joystick input before the game starts', () => {
+        controller.run('sendJoystickInput(1, 0);');
+        expect(desktop.run('gameState.targetDirection')).toBe(0);
+        expect(desktop.run('gameState.currentSpeed')).toBe(desktop.run('gameState.baseSpeed'));
+    });
+
+    it('starts the game from the controller center button', () => {
+        controller.run('handleCenterButtonPress();');
+        expect(desktop.run('gameState.currentState')).toBe('playing');
+        // The desktop's state push round-trips back to the controller UI.
+        expect($(controller, '#btn-center .center-icon').textContent).toBe('🐍');
+        expect($(controller, '#btn-center').disabled).toBe(true);
+    });
+
+    it('steers the snake from controller joystick input', () => {
+        controller.run('sendJoystickInput(0, -1);');
+        const expected = logic.joystickToControl(
+            { x: 0, y: -1 },
+            desktop.run('gameState.baseSpeed'),
+            { maxSpeedBoost: desktop.run('gameConfig.maxSpeedBoost') },
+        );
+        expect(desktop.run('gameState.targetDirection')).toBeCloseTo(expected.targetDirection);
+        expect(desktop.run('gameState.currentSpeed')).toBeCloseTo(expected.speed);
+
+        // Releasing the stick: coast at base speed, heading retained.
+        controller.run('sendJoystickInput(0, 0);');
+        expect(desktop.run('gameState.currentSpeed')).toBe(desktop.run('gameState.baseSpeed'));
+        expect(desktop.run('gameState.targetDirection')).toBeCloseTo(expected.targetDirection);
+    });
+
+    it('syncs game over to the controller share card', () => {
+        // Drive the real collision path: park the head inside the wall margin and step.
+        desktop.run('gameState.score = 40;');
+        desktop.run('gameState.snake[0] = { x: 5, y: 300 };');
+        desktop.run('moveSnake();');
+
+        expect(desktop.run('gameState.currentState')).toBe('game_over');
+        expect($(controller, '#btn-center .center-icon').textContent).toBe('↻');
+        expect($(controller, '#btn-center').disabled).toBe(false);
+        expect($(controller, '#mobile-game-over').classList.contains('hidden')).toBe(false);
+        // Score arrives purely through the JSON payload (separate windows, so this
+        // is not tautological).
+        expect($(controller, '#mobile-final-score').textContent).toBe('40');
+    });
+
+    it('restarts from the controller and resets desktop state', () => {
+        controller.run('handleCenterButtonPress();');
+
+        expect(desktop.run('gameState.currentState')).toBe('playing');
+        expect(desktop.run('gameState.score')).toBe(0);
+        expect(desktop.run('gameState.snake.length')).toBe(5);
+        expect($(controller, '#btn-center .center-icon').textContent).toBe('🐍');
+        expect($(controller, '#mobile-game-over').classList.contains('hidden')).toBe(true);
+        // The desktop consumed the one-shot action key after handling it.
+        expect(desktop.run(`localStorage.getItem('session_${SESSION}_action')`)).toBe(null);
+    });
+});


### PR DESCRIPTION
## 🎯 Description
Fixes the device-role race. Two independent code paths decided "desktop vs controller" on different timers:
- `main.js` checked **only** `innerWidth` and ran `initializeApp` at DOMContentLoaded + 1000 ms.
- The inline `revealApp` script computed `innerWidth <= 768 || ?session=` at load + 150 ms and overwrote `sessionManager.isDesktop`.

On any device **wider than 768px arriving with `?session=`** (tablet, landscape phone, the documented second-tab dev flow), whichever timer fired first decided whether the **desktop game** (new Firebase session + game loop!) or the controller booted.

Now `detectDevice()` is the single source of truth (viewport **or** `?session=`), `initializeApp` runs directly at DOMContentLoaded (no magic 1s delay — both session paths already handle Firebase-not-ready), and `revealApp` is cosmetic only: it reads `sessionManager.isDesktop`, never writes it. Bumped `CACHE` in sw.js since shell assets changed.

> **Merge order:** PR 3 of 6 — merge after #20. The protocol test from #20 is the regression net for this change.

## 🎮 Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## 🧪 Testing
### Test Environment:
- **OS**: Windows 11 · **Browsers**: Chromium (Claude preview) · local `python -m http.server` against `public/`

### Manual Testing Steps (all verified):
1. Wide viewport (1280px), plain URL → desktop view, session code generated, QR rendered, `isDesktop: true`.
2. Wide viewport (1280px), `?session=999999` → **controller view**, code prefilled, `isDesktop: false`, **no host session created** (`sessionManager.currentSession === null`, canvas never initialized) — this is the exact case that previously raced.
3. Narrow viewport (745px) → controller view.

Vitest (incl. the protocol test) runs in CI; not run locally (no Node).

## 📋 Checklist
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (preview console clean apart from pre-existing expected retry errors for a nonexistent session)

## 🔧 Breaking Changes
- [x] No breaking changes

## 🚀 Deployment Notes
- [x] No special deployment needed (merging deploys hosting as usual; SW cache bumped so installed clients refresh their offline shell on next load)
