### PR TITLE
fix(css): hide the multiplayer end card during a solo game-over

### DIFF
--- a/public/css/multiplayer.css
+++ b/public/css/multiplayer.css
@@ -99,8 +99,13 @@
 .mp-score-row--dead { opacity: 0.5; }
 .mp-score-row--dead .mp-row-score { color: var(--color-text-secondary); }
 
-/* ---------- Desktop end screen (#game-over gains .mp) ---------- */
-#game-over.mp .game-over-content:not(.mp-go-content) { display: none; }
+/* ---------- Desktop end screen (#game-over gains .mp for multiplayer) ----------
+   Solo and multiplayer share the #game-over container with two children; the `.mp`
+   class on #game-over swaps which one shows. BOTH directions must hide the other —
+   otherwise a SOLO game-over leaks the (empty) multiplayer end card beside the solo
+   card, and a multiplayer end-screen would show the solo card. */
+#game-over.mp .game-over-content:not(.mp-go-content) { display: none; } /* MP: hide the solo card */
+#game-over:not(.mp) .mp-go-content { display: none; }                   /* Solo: hide the MP end card */
 .mp-go-content { min-width: 380px; }
 #mp-winner-title {
     font-family: 'Orbitron', var(--font-family-base);

--- a/public/sw.js
+++ b/public/sw.js
@@ -5,7 +5,7 @@
 // cache is an OFFLINE FALLBACK only. All cross-origin traffic (Firebase, gstatic, unpkg, Font
 // Awesome) is left untouched so realtime sync keeps working. Bump CACHE when shell assets change.
 
-const CACHE = 'snake-shell-v30';
+const CACHE = 'snake-shell-v31';
 
 const SHELL_ASSETS = [
     './',


### PR DESCRIPTION
## 🎯 Description

Fixes the **solo game‑over screen** showing a stray, empty **multiplayer end card** beside the solo card (a lone `🏆`, blank standings, "Press ▶ on any phone to play again").

`#game-over` holds both children — the solo `.game-over-content` and the multiplayer `.mp-go-content` — and the `.mp` class is meant to swap which one shows. The CSS hid the **solo** card in MP mode but never hid the **MP** card in solo mode, so a solo game‑over rendered both. One symmetric rule restores the intended swap:

```css
#game-over:not(.mp) .mp-go-content { display: none; }   /* solo: hide the MP end card */
```

This is a **pre‑existing bug** (the rule predates the roadmap branch; it was on `master` too) surfaced from a user screenshot — not introduced by #32.

## 🎮 Type of Change
- [x] 🐛 Bug fix (non‑breaking)

## 🧪 Testing
- **In‑browser (headless desktop), both directions verified via computed styles:**
  - Solo game‑over (`#game-over` without `.mp`): solo card `block`, MP end card **`none`** (was leaking).
  - Multiplayer end (`.mp`): solo card `none`, MP card `block` — swap unchanged.
- `npm test` → **175 passed**; `npm run lint` → **0 errors**; `npm run check:globals` → in sync; `node --check public/sw.js` OK.

## 🔧 Breaking Changes
- [x] No breaking changes — CSS‑only display swap; no markup, JS, or data‑shape changes.

## 🚀 Deployment Notes
- [x] No special deployment needed beyond the standard hosting deploy.
- **No Firebase rule / infra changes.** CSS‑only + a service‑worker `CACHE` bump (`snake-shell-v30` → `v31`) so already‑installed clients pick up the fixed stylesheet on next reload (network‑first SW). Merging to `master` auto‑deploys hosting as usual.

---
- [x] Self‑reviewed · [x] tests pass locally (175/175) · [x] understand merge = deploy
