### PR TITLE
feat(controller): redesign mobile controller screen + refresh docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,10 +18,10 @@ jobs:
     
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '18'
           cache: 'npm'
@@ -44,7 +44,7 @@ jobs:
       - name: ☕ Set up Java (Firebase emulators)
         # The Firestore + RTDB emulators need a JRE. Pin it explicitly so the
         # emulator boot is deterministic, not reliant on the runner image default.
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,16 +13,19 @@ https://go-console-84748.web.app/
 - `npm install` — install dev tooling (`firebase-tools`, `eslint`, `vitest`, `prettier`).
 - `npm start` — serve `public/` locally (`npx serve -s public`). Open the printed URL; append
   `?session=123456` to force the mobile/controller view in a second tab/device.
-- `npm run lint` (ESLint) · `npm test` (Vitest — pure-logic unit tests in `tests/`) ·
-  `npm run format` (Prettier).
+- `npm run lint` (ESLint) · `npm run check:globals` (the single-scope globals guard — see Gotchas) ·
+  `npm test` (Vitest — pure-logic unit tests in `tests/`) · `npm run test:rules` (Firestore/RTDB
+  security-rule tests against the emulators; needs Java) · `npm run format` (Prettier).
 - **Deploy is automatic** on push to `master` via GitHub Actions
   (`.github/workflows/deploy.yml`, "Fast Deploy - CI/CD"), which runs `firebase deploy --only
   hosting,firestore,database` — the static site **and both rule sets** ship together, so
   `firestore.rules` / `database.rules.json` in this repo are the source of truth. Do **not** run
   `firebase deploy` by hand against production; test rule changes on a scratch project first
   (`.agent/workflows/deploy.md`).
-- CI is **blocking**: `lint`, `test` (Vitest, incl. the jsdom protocol smoke test in
-  `tests/protocol.test.js`), and a `node --check` syntax pass must all succeed before deploy.
+- CI is **blocking** (`.github/workflows/deploy.yml`), in order: `lint` → `check:globals`
+  (globals-list drift) → `test` (Vitest, incl. the jsdom protocol smoke test in
+  `tests/protocol.test.js`) → `test:rules` (emulated Firestore/RTDB security-rule assertions, allow
+  **and** deny) → a `node --check` syntax pass — all must succeed before deploy.
 
 ## Architecture (the non-obvious parts)
 
@@ -30,9 +33,9 @@ https://go-console-84748.web.app/
 order, all sharing one global scope:
 
 ```
-utils.js → logic.js → config.js → state.js → players.js → leaderboard.js → leaderboard-ui.js →
-sound.js → effects.js → mp-engine.js → network.js → mp-net.js → game.js → share.js → mp-ui.js →
-controller.js → mp-client.js → main.js
+utils.js → logic.js → config.js → consent.js → state.js → players.js → leaderboard.js →
+leaderboard-ui.js → sound.js → effects.js → mp-engine.js → network.js → mp-net.js → game.js →
+share.js → mp-ui.js → controller.js → mp-client.js → main.js
 ```
 
 Functions and the large mutable state objects (`gameState`, `sessionManager`, `joystickState`,
@@ -59,15 +62,20 @@ joystick input (RTDB) + actions (Firestore). Mobile captures the joystick and wr
 scales with joystick magnitude. Eating again within `gameConfig.comboWindowMs` builds a combo
 multiplier (capped at `maxCombo`), surfaced as a draining yellow badge over the board.
 
-**Analytics (GA4).** Firebase Analytics loads alongside the other SDKs; `config.js` creates a
-guarded `analytics` handle (its **own** try/catch so an analytics failure never drops the app into
-offline mode). Everything goes through one helper — `trackEvent(name, params)` in `utils.js` — which
-**no-ops when analytics is unavailable** (ad-block / offline) and **never throws into gameplay**,
+**Analytics (GA4) — consent-gated, OFF by default.** The GA4 SDK script loads with the other
+Firebase SDKs, but the handle is **never** created until the user opts in: `enableAnalytics()` in
+`config.js` is the **only** place `firebase.analytics()` is ever called, and `consent.js` decides
+whether to call it (an active **Accept**, or a returning visitor who previously accepted). No consent
+→ no `analytics` handle, no `_ga` cookies, no gtag runtime; `navigator.doNotTrack` /
+`globalPrivacyControl` auto-decline. Only the **desktop host** shows the consent banner (a phone
+arrives mid-join via `?session=`, so it inherits "declined until the host site is visited").
+Everything then goes through one helper — `trackEvent(name, params)` in `utils.js` — which **no-ops
+when analytics is unavailable** (declined / ad-block / offline) and **never throws into gameplay**,
 auto-tagging every event with `device_role` (`desktop_host` vs `phone_controller`). Custom events
 span the funnel (`session_created`, `controller_arrival`, `controller_connected`,
-`game_start`/`game_restart`, `game_over`/`post_score`, `share`, `mute_toggle`, `pwa_install`); GA4
-auto-captures audience + `utm_*` acquisition. **Never log PII or the 6-digit session code.** Full
-reference + how to view: `.agent/system/analytics.md`.
+`game_start`/`game_restart`, `game_over`/`post_score`, `share`, `mute_toggle`, `pwa_install`,
+`consent_update`); GA4 auto-captures audience + `utm_*` acquisition. **Never log PII or the 6-digit
+session code.** Full reference + how to view: `.agent/system/analytics.md`.
 
 **Phone-controller capabilities (graceful degradation).** The controller leans on a cluster of
 *optional* browser APIs — `navigator.vibrate` (with an iOS `<input switch>` haptic shim), Web Share,
@@ -81,8 +89,11 @@ capability/browser support matrix + manual re-verify checklist lives in
 - `js/utils.js` — small shared helpers, incl. `trackEvent()` (the hardened GA4 analytics wrapper).
 - `js/logic.js` — **pure, testable** game math: joystick→angle/speed mapping, collision, turn step.
   Unit-tested in `tests/` (the only code with real coverage).
-- `js/config.js` — Firebase init (incl. the guarded `analytics` / GA4 handle) + all tunables
-  (`gameConfig`) + `colors` + `GameState` enum.
+- `js/config.js` — Firebase init + `enableAnalytics()` (the **sole** `firebase.analytics()` call,
+  consent-gated) + all tunables (`gameConfig`, incl. `maxPlayers`) + `colors` + `GameState` enum.
+- `js/consent.js` — the GA4 **consent gate** + privacy-policy modal: resolves the stored decision
+  (`snake_consent` in `localStorage`), honours DNT/GPC, shows the host-only consent banner, and
+  calls `enableAnalytics()` only on opt-in. Pure helpers exported for Vitest.
 - `js/state.js` — the global mutable state objects.
 - `js/leaderboard.js` — local high scores (`localStorage`) **plus** the global Firestore
   leaderboard: per-device id/handle, score submission (monotonic, rules-validated), and the
@@ -99,12 +110,16 @@ capability/browser support matrix + manual re-verify checklist lives in
 - **Multiplayer (1–`gameConfig.maxPlayers` players, "last snake standing")** — modular, each file
   ≤~250 lines: `js/players.js` (slots/colors/factories — `maxPlayers` is THE knob; rules already
   accept p1–p6), `js/mp-engine.js` (the N-snake simulation; `gameState.mode === 'multi'`),
-  `js/mp-net.js` (desktop sync: roster, per-slot joystick/actions, results), `js/mp-client.js`
-  (phone: race-safe slot claim with rejoin token, own-slot haptics), `js/mp-ui.js` (lobby chips,
-  scoreboard, end screen, phone identity — all generated from `PLAYER_SLOTS`). 1-player rounds run
-  the CLASSIC solo engine incl. the leaderboard; ≥2 use the arena (no leaderboard).
+  `js/mp-net.js` (desktop sync: roster, **per-slot RTDB listeners** for O(1) joystick/actions,
+  results, **plus presence & host-resilience — `onDisconnect`-first, reconcile, stale-player
+  eviction**), `js/mp-client.js` (phone: race-safe slot claim with rejoin token, own-slot haptics,
+  presence heartbeat), `js/mp-ui.js` (lobby chips, scoreboard, end screen, phone identity — all
+  generated from `PLAYER_SLOTS`). 1-player rounds run the CLASSIC solo engine incl. the leaderboard;
+  ≥2 use the arena (no leaderboard).
 - `css/` — load order `variables.css` (tokens) → `base.css` → `desktop.css` / `mobile.css` →
-  `leaderboard.css` → `multiplayer.css`.
+  `leaderboard.css` → `multiplayer.css`. `mobile.css` holds the responsive three-zone controller
+  layout (`100dvh` + `env(safe-area-inset-*)` aware); `multiplayer.css` adds the phone
+  player-identity / queue states (player-color tint, ready-pulse, queued dimming).
 - `sw.js` + `manifest.json` — PWA: installable + offline shell. The SW is **network-first** for
   same-origin requests (cache = offline fallback only); bump `CACHE` when shell assets change.
 
@@ -127,8 +142,10 @@ capability/browser support matrix + manual re-verify checklist lives in
   documented in `.agent/system/firebase_schema.md`.
 - Everything shares global scope — renaming a function or variable can break a consumer in
   another file. ESLint's `no-undef` is **on** (error) with every cross-file global declared in
-  `.eslintrc.json` `globals`: when you add/rename/remove a top-level function or `let`/`const`
-  in `public/js/*`, update that list or CI fails (that failure is the feature).
+  `.eslintrc.json` `globals`, and a dedicated guard (`npm run check:globals`, run in CI via
+  `scripts/check-globals.mjs`) fails the build if that list **drifts in either direction** from the
+  top-level declarations in `public/js/*`: when you add/rename/remove a top-level function or
+  `let`/`const`, update that list or CI fails (that failure is the feature).
 - **ESLint `no-unused-vars` false positives** are expected for cross-file *functions* (e.g.
   `submitGlobalScore` is defined in `leaderboard.js` but called from `game.js`): ESLint lints each
   file alone, so it can't see those reads. They're **warnings** (the lint command still exits 0) —

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ Thank you for your interest in contributing! We welcome contributions from devel
 // Use modern ES6+ syntax
 const gameConfig = {
     speed: 2.0,
-    maxPlayers: 2
+    maxPlayers: 3
 };
 
 // Use descriptive variable names
@@ -180,11 +180,12 @@ function handleJoystickInput(input) {
 ```
 ├── public/                 # Everything that ships (Firebase Hosting serves this)
 │   ├── css/                # variables → base → desktop / mobile (load order matters)
-│   ├── js/                 # 13 plain <script>s, one shared global scope, no bundler
+│   ├── js/                 # 19 plain <script>s, one shared global scope, no bundler
 │   ├── index.html          # both views: desktop host + mobile controller
 │   ├── sw.js               # network-first service worker (PWA offline shell)
 │   └── manifest.json       # PWA manifest
-├── tests/                  # Vitest unit tests for js/logic.js
+├── tests/                  # Vitest: pure logic, jsdom protocol smoke, capability + mp-presence,
+│                           #   and emulated Firebase-rules tests (npm run test:rules)
 ├── firebase.json           # Firebase Hosting config
 ├── .github/workflows/      # GitHub Actions CI/CD (auto-deploy on master)
 ├── CLAUDE.md               # architecture map for contributors & AI agents

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Scan a QR code and your phone becomes a wireless, analog joystick.
 
 ## ✨ Features
 
-- 📱 **Phone-as-controller** — a custom touch joystick streamed to the desktop in near real-time over Firebase.
+- 📱 **Phone-as-controller** — a polished, responsive analog joystick (notch / safe-area aware) streamed to the desktop in near real-time over Firebase.
 - 🎯 **Analog, continuous-angle movement** — steer by angle; magnitude controls speed. No grid-snapping.
 - ⚔️ **2–3 player versus** — friends scan the *same* QR to join; one shared fruit, distinct snake colors, bite a rival and *you* die — **last snake standing wins** ("I defeated…" bragging cards included).
 - 🔥 **Combo streaks** — chain quick eats for a score multiplier, shown as a draining yellow timer badge.
@@ -37,9 +37,10 @@ Scan a QR code and your phone becomes a wireless, analog joystick.
 - 🏆 **Global leaderboard** — pick a handle and compete worldwide; see "You ranked #N globally" after every run.
 - 📳 **Haptics + loss flash** — the phone buzzes on loss (Android; best-effort iOS) with an on-screen shake where it can't.
 - 🤳 **Flex your score** — share to WhatsApp, X, Facebook, or Instagram straight from your phone.
-- ⚡ **Offline-ready PWA** — installable, with a network-first service worker.
+- 🛰️ **Resilient sessions** — presence tracking with `onDisconnect`, host-takeover reconcile, and stale-player eviction keep multiplayer rounds clean when a phone drops or the host refreshes.
+- ⚡ **Offline-ready PWA** — installable, with a network-first service worker and an "update available" reload prompt.
 - 🛟 **Single-device fallback** — a `localStorage` mode kicks in automatically when Firebase isn't available.
-- 📊 **Audience analytics** — Google Analytics 4 for audience + campaign insight, tagged desktop-host vs. phone-controller. IP-anonymized, and it never blocks gameplay.
+- 🔒 **Privacy-first analytics** — Google Analytics 4 is **off by default** and never loads until you accept the consent banner (it also honors Do-Not-Track / Global Privacy Control). IP-anonymized, tagged desktop-host vs. phone-controller, and it never blocks gameplay.
 
 ---
 

--- a/public/css/mobile.css
+++ b/public/css/mobile.css
@@ -112,51 +112,183 @@
 .connection-status.is-error   { color: var(--color-error); }
 .connection-status.is-info    { color: var(--color-warning); }
 
+/* ──────────────────────────────────────────────────────────────────────────
+   CONTROLLER REDESIGN — "Quiet Console" (three-zone layout: identity / hero / play)
+   The old layout centered three items with gap:8vh + padding:6vh, clumping the
+   content in the middle and leaving ~half the screen as dead padding. This uses a
+   grid (auto 1fr auto) so the middle row absorbs all slack and the joystick stays
+   the optical hero whether the MP banner is present (multiplayer) or absent (solo).
+   All values resolve through existing tokens (light/dark) and the .mp/.mp-queued
+   states keep working via multiplayer.css. iOS dvh + safe-area aware.
+   ────────────────────────────────────────────────────────────────────────── */
 .controller-interface {
     display: none;
     width: 100vw;
-    height: 100vh;
+    height: 100vh;            /* fallback FIRST for older iOS (< 15.4) */
+    height: 100dvh;           /* track the iOS dynamic toolbar */
     overflow: hidden;
     position: absolute;
     top: 0;
     left: 0;
 }
 
-.joystick-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100vh;
-    width: 100vw;
-    gap: 8vh;
-    padding: 6vh 6vw;
+/* Intentional depth over the body grid/particles: a soft primary radial wash
+   behind the hero + a bottom vignette grounding the play zone. Static (no anim). */
+.controller-interface::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+    background:
+        radial-gradient(120% 60% at 50% 44%,
+            rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.10) 0%,
+            rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.04) 40%,
+            transparent 72%),
+        linear-gradient(180deg,
+            rgba(var(--color-background-rgb), 0) 0%,
+            rgba(var(--color-background-rgb), 0) 55%,
+            rgba(var(--color-background-rgb), 0.35) 100%);
 }
 
+.joystick-container {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-rows: auto 1fr auto;   /* top identity · hero (eats slack) · play */
+    align-items: center;
+    justify-items: center;
+    box-sizing: border-box;
+    height: 100vh;                       /* fallback FIRST */
+    height: 100dvh;
+    width: 100vw;
+    gap: var(--space-16);
+    padding:
+        calc(env(safe-area-inset-top, 0px) + var(--space-20))
+        calc(env(safe-area-inset-right, 0px) + var(--space-20))
+        calc(env(safe-area-inset-bottom, 0px) + var(--space-24))
+        calc(env(safe-area-inset-left, 0px) + var(--space-20));
+}
+
+/* TOP ZONE — always-present status bar. In SOLO it fills the top band so it is
+   never empty padding; in MULTIPLAYER it is hidden and #mp-player-banner owns
+   the row instead. Decorative only (aria-hidden in the markup), no JS. */
+.controller-brand {
+    grid-row: 1;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-12);
+    padding: var(--space-6) var(--space-12);
+    border-radius: var(--radius-full);
+    border: 1px solid rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.22);
+    background: linear-gradient(135deg,
+        rgba(var(--color-surface-rgb), 0.65),
+        rgba(var(--color-surface-rgb), 0.30));
+    box-shadow:
+        0 2px 10px -4px rgba(var(--color-slate-900-rgb), 0.30),
+        var(--shadow-inset-sm);
+}
+.controller-interface.mp .controller-brand { display: none; }
+
+.controller-brand .brand-name {
+    font-family: 'Orbitron', var(--font-family-base);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-bold);
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--color-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Status pill: calm "Connected" success by default; recolors to warning under
+   .mp-queued (rule in multiplayer.css). Pure CSS, no JS. */
+.controller-brand .brand-status {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-6);
+    padding: var(--space-2) var(--space-10);
+    border-radius: var(--radius-full);
+    font-family: 'Orbitron', var(--font-family-base);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: 0.10em;
+    text-transform: uppercase;
+    color: var(--color-success);
+    background: rgba(var(--color-success-rgb), 0.14);
+    border: 1px solid rgba(var(--color-success-rgb), 0.30);
+}
+.controller-brand .brand-status::before {
+    content: "";
+    width: 7px;
+    height: 7px;
+    border-radius: var(--radius-full);
+    background: var(--color-success);
+    box-shadow: 0 0 8px rgba(var(--color-success-rgb), 0.9);
+}
+
+/* Keep the MP identity banner anchored to the top zone when present. */
+.mp-player-banner { grid-row: 1; }
+
+/* MIDDLE ZONE — the hero joystick, vertically centered in the freed-up 1fr space. */
 .joystick-area {
+    grid-row: 2;
     display: flex;
     align-items: center;
     justify-content: center;
     width: 100%;
     position: relative;
+    /* NB: never set overflow:hidden here — it would clip the glow ::before */
 }
 
-/* First-run joystick hint — reuses the .mp-center-hint recipe (color/size/centering).
-   Sits just below the stick (absolute so it never shifts the joystick layout) and is
-   pointer-events:none so it can NEVER intercept the very first drag it's teaching. */
+/* A single ambient glow behind the stick (the biggest "premium" move). Retints to
+   the player color in MP via the fallback chain. pointer-events:none so it can
+   NEVER steal the first touch. */
+.joystick-area::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 78vw;
+    height: 78vw;
+    max-width: 340px;
+    max-height: 340px;
+    transform: translate(-50%, -50%);
+    border-radius: var(--radius-full);
+    pointer-events: none;
+    z-index: 0;
+    background: radial-gradient(circle,
+        rgba(var(--player-color-rgb, var(--color-primary-rgb, var(--color-teal-500-rgb))), 0.22) 0%,
+        rgba(var(--player-color-rgb, var(--color-primary-rgb, var(--color-teal-500-rgb))), 0.08) 45%,
+        transparent 70%);
+    animation: joyGlowBreath 6s ease-in-out infinite;
+}
+@keyframes joyGlowBreath {
+    0%, 100% { opacity: 0.75; transform: translate(-50%, -50%) scale(1); }
+    50%      { opacity: 1;    transform: translate(-50%, -50%) scale(1.05); }
+}
+
+/* First-run joystick hint — stays ABSOLUTE + pointer-events:none so it never
+   reflows the stick off optical-center and never intercepts the first drag. */
 .joystick-hint {
     color: var(--color-text-secondary);
-    font-size: var(--font-size-sm);
+    font-size: var(--font-size-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
     text-align: center;
     position: absolute;
     top: 100%;
     left: 50%;
     transform: translateX(-50%);
-    margin-top: var(--space-8);
+    margin-top: var(--space-16);
     width: max-content;
     max-width: 90vw;
     pointer-events: none;
-    opacity: 1;
+    opacity: 0.85;
     transition: opacity var(--duration-normal) var(--ease-standard);
 }
 
@@ -165,70 +297,133 @@
     opacity: 0;
 }
 
+/* The stick itself — a recessed dish; depth via slate-900 token shadows so it
+   still reads on the bright cream (light-mode) surface. */
 .joystick-base {
-    width: 40vw;
-    height: 40vw;
-    max-width: 200px;
-    max-height: 200px;
-    min-width: 120px;
-    min-height: 120px;
-    border-radius: var(--radius-full);
-    background: linear-gradient(145deg, var(--color-surface), var(--color-background));
-    border: 3px solid rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.4);
     position: relative;
+    z-index: 1;
+    width: 46vw;
+    height: 46vw;
+    max-width: 220px;
+    max-height: 220px;
+    min-width: 132px;
+    min-height: 132px;
+    border-radius: var(--radius-full);
+    background:
+        radial-gradient(circle at 50% 38%,
+            rgba(var(--color-background-rgb), 0.9),
+            rgba(var(--color-surface-rgb), 0.9) 72%),
+        linear-gradient(145deg, var(--color-surface), var(--color-background));
+    border: 2px solid rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.45);
     display: flex;
     align-items: center;
     justify-content: center;
     cursor: pointer;
+    box-shadow:
+        0 16px 38px -12px rgba(var(--color-slate-900-rgb), 0.45),
+        inset 0 2px 0 rgba(255, 255, 255, 0.12),
+        inset 0 -12px 26px -8px rgba(var(--color-slate-900-rgb), 0.32),
+        inset 0 0 0 8px rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.05);
 }
 
+/* Convex thumb cap — a radial highlight over the teal/player gradient. */
 .joystick-handle {
-    width: 35%;
-    height: 35%;
+    width: 38%;
+    height: 38%;
     border-radius: var(--radius-full);
-    background: linear-gradient(145deg, var(--color-primary), var(--color-teal-600));
-    border: 2px solid rgba(255, 255, 255, 0.3);
+    background:
+        radial-gradient(circle at 38% 32%, rgba(255, 255, 255, 0.45), transparent 55%),
+        linear-gradient(145deg, var(--color-primary), var(--color-teal-600));
+    border: 2px solid rgba(255, 255, 255, 0.30);
     position: absolute;
-    transition: all 0.1s ease-out;
+    /* transform is driven inline by the drag (translate); keep it transitionable */
+    transition: transform 0.1s ease-out, box-shadow var(--duration-fast) var(--ease-standard);
     cursor: grab;
+    box-shadow:
+        0 6px 14px -4px rgba(var(--color-slate-900-rgb), 0.55),
+        inset 0 2px 2px rgba(255, 255, 255, 0.30),
+        inset 0 -4px 8px -2px rgba(var(--color-slate-900-rgb), 0.25);
 }
 
 .joystick-handle.dragging {
     cursor: grabbing;
-    transform: scale(1.1);
+    box-shadow:
+        0 10px 22px -6px rgba(var(--color-slate-900-rgb), 0.60),
+        inset 0 2px 2px rgba(255, 255, 255, 0.35);
 }
 
+/* BOTTOM ZONE — the play affordance (button + caption stacked). */
 .center-control {
+    grid-row: 3;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
+    gap: var(--space-12);
     width: 100%;
 }
 
+/* BASE read. DISABLED (PLAYING) = muted recessed plate; READY/RESTART (enabled)
+   = inviting ring + gentle breathing pulse. Disabled is the base so there is no
+   inversion flash on state change. */
 .center-btn {
-    width: 25vw;
-    height: 25vw;
-    max-width: 120px;
-    max-height: 120px;
-    min-width: 80px;
-    min-height: 80px;
+    position: relative;
+    z-index: 1;
+    width: 26vw;
+    height: 26vw;
+    max-width: 116px;
+    max-height: 116px;
+    min-width: 84px;
+    min-height: 84px;
     border-radius: var(--radius-full) !important;
-    border: none;
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
-    position: relative;
-    overflow: hidden;
-    border: 3px solid rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.4);
+    overflow: visible;           /* let the ready ring escape the edge */
+    border: 2px solid rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.45);
     background: linear-gradient(145deg, var(--color-surface), var(--color-background));
     color: var(--color-primary);
+    box-shadow: 0 10px 24px -10px rgba(var(--color-slate-900-rgb), 0.40);
+    transition:
+        transform var(--duration-fast) var(--ease-standard),
+        box-shadow var(--duration-normal) var(--ease-standard),
+        border-color var(--duration-normal) var(--ease-standard),
+        opacity var(--duration-normal) var(--ease-standard);
 }
 
 .center-btn:disabled {
-    opacity: 0.5;
+    opacity: 0.45;
     cursor: not-allowed;
     color: var(--color-text-secondary);
+    border-color: rgba(var(--color-info-rgb, var(--color-slate-500-rgb)), 0.30);
+    background: linear-gradient(145deg, var(--color-background), var(--color-surface));
+    box-shadow:
+        inset 0 3px 8px rgba(var(--color-slate-900-rgb), 0.30),
+        inset 0 -2px 4px rgba(255, 255, 255, 0.05);
+    animation: none;
+}
+
+.center-btn:not(:disabled) {
+    border-color: rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.80);
+    box-shadow:
+        0 0 0 0 rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.45),
+        0 10px 26px -10px rgba(var(--color-slate-900-rgb), 0.45);
+    animation: readyPulse 2.4s ease-in-out infinite;
+}
+@keyframes readyPulse {
+    0%, 100% {
+        box-shadow:
+            0 0 0 0 rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.45),
+            0 10px 26px -10px rgba(var(--color-slate-900-rgb), 0.45);
+        transform: scale(1);
+    }
+    50% {
+        box-shadow:
+            0 0 0 12px rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0),
+            0 14px 30px -10px rgba(var(--color-slate-900-rgb), 0.50);
+        transform: scale(1.04);
+    }
 }
 
 .center-btn:not(:disabled):hover {
@@ -240,14 +435,14 @@
     background: linear-gradient(145deg, var(--color-primary), var(--color-teal-600));
     color: var(--color-btn-primary-text);
     transform: scale(0.95);
+    animation: none;             /* settle on press */
 }
 
 .center-icon {
-    font-size: 5vw;
-    max-font-size: 2.5rem;
-    min-font-size: 1.5rem;
+    font-size: clamp(1.5rem, 5vw, 2.5rem);
     font-weight: var(--font-weight-bold);
     line-height: 1;
+    margin-left: 3px;            /* optically center the ▶ glyph */
 }
 
 @media (max-width: 768px) {
@@ -284,52 +479,87 @@
     }
     
     .joystick-base {
-        width: 45vw;
-        height: 45vw;
-        max-width: 180px;
-        max-height: 180px;
-        min-width: 100px;
-        min-height: 100px;
+        width: 52vw;
+        height: 52vw;
+        max-width: 200px;
+        max-height: 200px;
+        min-width: 120px;
+        min-height: 120px;
     }
-    
+
+    .joystick-area::before {
+        width: 84vw;
+        height: 84vw;
+    }
+
     .center-btn {
         width: 30vw;
         height: 30vw;
-        max-width: 100px;
-        max-height: 100px;
-        min-width: 70px;
-        min-height: 70px;
-    }
-    
-    .center-icon {
-        font-size: 6vw;
+        max-width: 104px;
+        max-height: 104px;
+        min-width: 80px;     /* keep >= iOS 44px tap floor */
+        min-height: 80px;
     }
 }
 
-/* Mobile Landscape Optimization */
+/* Mobile Landscape Optimization — two columns (joystick left, play right),
+   identity spans the top row, hint hidden (no room), tap floors preserved. */
 @media (max-height: 500px) and (orientation: landscape) {
     .joystick-container {
-        flex-direction: row;
-        gap: 15vw;
-        padding: 4vh 8vw;
+        grid-template-rows: auto 1fr;
+        grid-template-columns: 1fr 1fr;
+        align-items: center;
+        justify-items: center;
+        gap: var(--space-12) 10vw;
+        padding:
+            calc(env(safe-area-inset-top, 0px) + var(--space-10))
+            calc(env(safe-area-inset-right, 0px) + 6vw)
+            calc(env(safe-area-inset-bottom, 0px) + var(--space-10))
+            calc(env(safe-area-inset-left, 0px) + 6vw);
     }
-    
+    .controller-brand,
+    .mp-player-banner { grid-row: 1; grid-column: 1 / -1; }
+    .joystick-area  { grid-row: 2; grid-column: 1; }
+    .center-control { grid-row: 2; grid-column: 2; }
+    /* the hint would overlap the short viewport / play column — hide it */
+    .joystick-hint { display: none; }
+
     .joystick-base {
-        width: 30vw;
-        height: 30vw;
+        width: 32vw;
+        height: 32vw;
         max-width: 150px;
         max-height: 150px;
+        min-width: 110px;
+        min-height: 110px;
     }
-    
+    .joystick-area::before {
+        width: 40vw;
+        height: 40vw;
+        max-width: 220px;
+        max-height: 220px;
+    }
     .center-btn {
-        width: 20vw;
-        height: 20vw;
+        width: 22vw;
+        height: 22vw;
         max-width: 100px;
         max-height: 100px;
+        min-width: 80px;     /* keep the iOS tap floor in landscape */
+        min-height: 80px;
     }
-
     .center-icon {
-        font-size: 4vw;
+        font-size: clamp(1.3rem, 4vw, 2rem);
+    }
+}
+
+/* Reduced motion: freeze the ambient glow + ready pulse into a static, still
+   clearly-inviting state. (The MP-tinted pulse is frozen in multiplayer.css.) */
+@media (prefers-reduced-motion: reduce) {
+    .joystick-area::before { animation: none; opacity: 0.9; }
+    .center-btn:not(:disabled) {
+        animation: none;
+        box-shadow:
+            0 0 0 4px rgba(var(--color-primary-rgb, var(--color-teal-500-rgb)), 0.28),
+            0 10px 26px -10px rgba(var(--color-slate-900-rgb), 0.45);
     }
 }
 

--- a/public/css/multiplayer.css
+++ b/public/css/multiplayer.css
@@ -131,14 +131,65 @@
     border-color: rgba(var(--player-color-rgb, var(--color-teal-500-rgb)), 0.5);
 }
 .controller-interface.mp .joystick-handle {
-    background: linear-gradient(145deg, var(--player-color, var(--color-primary)),
-        rgba(var(--player-color-rgb, var(--color-teal-500-rgb)), 0.75));
+    /* keep the convex white highlight (mobile.css) over the player-color gradient */
+    background:
+        radial-gradient(circle at 38% 32%, rgba(255, 255, 255, 0.45), transparent 55%),
+        linear-gradient(145deg, var(--player-color, var(--color-primary)),
+            rgba(var(--player-color-rgb, var(--color-teal-500-rgb)), 0.75));
 }
 .controller-interface.mp .center-btn {
     border-color: rgba(var(--player-color-rgb, var(--color-teal-500-rgb)), 0.5);
 }
+
+/* Ready/restart pulse, recolored to the player's color (keyframes can't read a
+   CSS var for color stops, so re-point at a player-colored duplicate). */
+.controller-interface.mp .center-btn:not(:disabled) {
+    border-color: rgba(var(--player-color-rgb, var(--color-teal-500-rgb)), 0.80);
+    animation: readyPulseMp 2.4s ease-in-out infinite;
+}
+@keyframes readyPulseMp {
+    0%, 100% {
+        box-shadow:
+            0 0 0 0 rgba(var(--player-color-rgb, var(--color-teal-500-rgb)), 0.45),
+            0 10px 26px -10px rgba(var(--color-slate-900-rgb), 0.45);
+        transform: scale(1);
+    }
+    50% {
+        box-shadow:
+            0 0 0 12px rgba(var(--player-color-rgb, var(--color-teal-500-rgb)), 0),
+            0 14px 30px -10px rgba(var(--color-slate-900-rgb), 0.50);
+        transform: scale(1.04);
+    }
+}
+
+/* QUEUED behind a live round: dim the stage AND freeze the glow + ready pulse so
+   a waiting player's button never keeps breathing. */
 .controller-interface.mp-queued .joystick-area { opacity: 0.35; pointer-events: none; }
+.controller-interface.mp-queued .joystick-area::before { animation: none; opacity: 0.4; }
 .controller-interface.mp-queued .center-btn { opacity: 0.35; }
+.controller-interface.mp-queued .center-btn:not(:disabled) { animation: none; }
+
+/* Status pill recolors to a calm "waiting" warning when queued (harmless safeguard;
+   the brand bar is hidden under .mp, but keeps the token semantics consistent). */
+.controller-interface.mp-queued .controller-brand .brand-status {
+    color: var(--color-warning);
+    background: rgba(var(--color-warning-rgb), 0.14);
+    border-color: rgba(var(--color-warning-rgb), 0.30);
+}
+.controller-interface.mp-queued .controller-brand .brand-status::before {
+    background: var(--color-warning);
+    box-shadow: 0 0 8px rgba(var(--color-warning-rgb), 0.9);
+}
+
+/* Reduced motion: kill the MP duplicate pulse too; keep a static inviting ring. */
+@media (prefers-reduced-motion: reduce) {
+    .controller-interface.mp .center-btn:not(:disabled) {
+        animation: none;
+        box-shadow:
+            0 0 0 4px rgba(var(--player-color-rgb, var(--color-teal-500-rgb)), 0.28),
+            0 10px 26px -10px rgba(var(--color-slate-900-rgb), 0.45);
+    }
+}
 
 .mp-player-banner {
     display: flex; align-items: center; gap: var(--space-8);

--- a/public/index.html
+++ b/public/index.html
@@ -364,6 +364,14 @@
         <!-- Controller Interface - Joystick Style -->
         <div id="controller-interface" class="controller-interface">
             <div class="joystick-container">
+                <!-- Top status bar (decorative). Fills the top zone in SOLO; hidden in
+                     multiplayer (via .controller-interface.mp .controller-brand) so the
+                     identity banner below owns the row. aria-hidden — no a11y/JS surface. -->
+                <div class="controller-brand" aria-hidden="true">
+                    <span class="brand-name">Snake</span>
+                    <span class="brand-status">Connected</span>
+                </div>
+
                 <!-- Multiplayer identity banner: "You are ● Player 2 — Sam" -->
                 <div id="mp-player-banner" class="mp-player-banner hidden">
                     <span class="mp-chip-dot" aria-hidden="true"></span>


### PR DESCRIPTION
## 🎯 Description

Redesigns the **phone controller screen** and refreshes the docs to match recent work.

**Controller redesign** — the old layout centered three items with `gap: 8vh` + `padding: 6vh`, so on a 375×812 phone ~196px sat dead above the banner and ~184px below the play button (≈47% of the screen was empty padding, with a faint, ghosted play button floating in the middle). It now uses a deliberate **three-zone grid** (`grid-template-rows: auto 1fr auto`) — identity on top, a hero joystick centered in the `1fr` middle that absorbs all slack, and the play button anchored at the bottom. Plus: an ambient glow behind the joystick (retints to the player color in multiplayer), a recessed-dish base + convex thumb cap, an inviting ready/restart pulse on the play button with a clearly-muted disabled state, an always-present top status bar that fills the top zone in solo (hidden in MP), iOS `100dvh` + `env(safe-area-inset-*)`, a two-column landscape layout, and `prefers-reduced-motion` guards. Scoped entirely to `.mobile-view` / `.controller-interface` — the desktop view is untouched.

**Docs** — brought `README.md`, `CLAUDE.md`, and `CONTRIBUTING.md` back in line with the tree: documented the GA4 **consent gate** (`consent.js`, analytics off by default, honours DNT/GPC), added `consent.js` to CLAUDE's load order + file roles, documented the `check:globals` and emulated `test:rules` CI gates, noted per-slot RTDB listeners + multiplayer presence/host-resilience, and corrected stale facts in CONTRIBUTING (`13`→`19` scripts, `maxPlayers: 2`→`3`).

## 🎮 Type of Change
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update

## 🧪 Testing

### Test Environment
- **OS**: Windows 11
- **Tooling**: Node v24, ran against a local static server (`python -m http.server`)

### What was verified
- `npm run lint` → 0 errors (50 pre-existing cross-file `no-unused-vars` warnings).
- `npm run check:globals` → in sync (287 globals).
- `npm test` → **175/175 pass** (11 files).
- Layout measured live in the preview at 375×812: dead space dropped from ~196px (top) / ~184px (bottom) to ~32px / ~24px of intentional padding; grid resolves `46px / 549px(1fr) / 140px`.
- Verified via computed styles: glow + ready-pulse animate and retint to the player color in MP; disabled button resolves to `opacity 0.45` + muted grey border + recessed inset shadow; solo shows the full-width brand bar; light & dark palettes resolve; landscape becomes a two-column grid with the hint hidden and no overflow.

### Not verified
- No live two-device multiplayer round was run (single-machine env).
- iOS Safari `dvh` / safe-area behaviour is correct by construction but not tested on a physical device.
- `npm run test:rules` not run locally (no Java/emulators here); CI runs it. No rules files were touched, so no rule impact.

### Manual repro
1. Serve `public/` and open with a phone-width viewport (or append `?session=123456`).
2. Force the controller view to confirm the three-zone layout, hero joystick glow, and the play-button ready-pulse; toggle the button's `disabled` to see the muted state.

## 📷 Screenshots or Videos
Real preview screenshots time out in this environment, so none are attached. The redesign was verified through layout measurements and computed-style checks (above); a faithful before/after reconstruction was shared with the author in-session.

## 📋 Checklist
- [x] My code follows the project's style guidelines (token-only CSS, kebab-case classes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## 📱 Mobile Testing
- [x] Mobile UI is responsive (portrait, landscape, ≤480px breakpoints verified in preview)
- [x] Joystick drag logic unchanged (only styling touched; inline `transform` translate still drives the handle)
- [ ] Works on iOS Safari — built for it (`dvh` + safe-area) but not yet verified on a physical device

## 🔧 Breaking Changes
- [x] No breaking changes

## 🚀 Deployment Notes
- [x] No special deployment needed
- Touches `public/` (CSS + one decorative HTML element) → merging to `master` auto-deploys the static site via CI. **No** Firebase rule changes (`firestore.rules` / `database.rules.json` untouched). Installed PWA users get the fresh shell on next reload (service worker is network-first).
